### PR TITLE
refactor: use API client for backend calls

### DIFF
--- a/components/create-chatter-form.tsx
+++ b/components/create-chatter-form.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { toast } from "@/hooks/use-toast"
+import { api } from "@/lib/api"
 
 export function CreateChatterForm() {
   const [username, setUsername] = useState("")
@@ -34,25 +35,18 @@ export function CreateChatterForm() {
     setIsLoading(true)
 
     try {
-      const response = await fetch("/api/create-chatter", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username,
-          password,
-          currency,
-          commissionRate: parseDecimalInput(commissionRate),
-          platformFeeRate: parseDecimalInput(platformFeeRate),
-        }),
+      const createdUser = await api.createUser({
+        username,
+        password,
+        role: "chatter",
       })
 
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to create chatter account")
-      }
+      await api.createChatter({
+        userId: createdUser.id,
+        currency,
+        commissionRate: parseDecimalInput(commissionRate),
+        platformFeeRate: parseDecimalInput(platformFeeRate),
+      })
 
       toast({
         title: "Success",
@@ -65,10 +59,10 @@ export function CreateChatterForm() {
       setCurrency("€")
       setCommissionRate("8,00")
       setPlatformFeeRate("20,00")
-    } catch (error) {
+    } catch (error: any) {
       toast({
         title: "Error",
-        description: error instanceof Error ? error.message : "Failed to create account",
+        description: error?.message || "Failed to create account",
         variant: "destructive",
       })
     } finally {

--- a/components/setup-manager.tsx
+++ b/components/setup-manager.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { useState } from "react"
+import { api } from "@/lib/api"
 
 export function SetupManager() {
   const [isLoading, setIsLoading] = useState(false)
@@ -15,21 +16,18 @@ export function SetupManager() {
     setMessage(null)
 
     try {
-      const response = await fetch("/api/create-manager", {
-        method: "POST",
+      await api.createUser({
+        username: "WolfMas",
+        password: "WolfMas0904",
+        fullName: "WolfMas",
+        role: "manager",
       })
 
-      const data = await response.json()
-
-      if (response.ok) {
-        setMessage(
-          "Manager account created successfully! You can now login with username: WolfMas and password: WolfMas0904",
-        )
-      } else {
-        setError(data.error || "Failed to create manager account")
-      }
-    } catch (error) {
-      setError("Network error occurred")
+      setMessage(
+        "Manager account created successfully! You can now login with username: WolfMas and password: WolfMas0904",
+      )
+    } catch (error: any) {
+      setError(error?.message || "Failed to create manager account")
     } finally {
       setIsLoading(false)
     }


### PR DESCRIPTION
## Summary
- route manager setup through centralized API client
- create chatter accounts using API client instead of direct fetch

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adce2c5284832798b2f2384fd5a5bc