### PR TITLE
refactor: use API client for backend calls

### DIFF
--- a/components/chatters-list.tsx
+++ b/components/chatters-list.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Plus, Search, Clock, DollarSign, Trash2, UserX, UserCheck } from "lucide-react"
+import { api } from "@/lib/api"
 
 interface Chatter {
   id: string
@@ -76,40 +77,40 @@ export function ChattersList() {
 
   const fetchChatters = async () => {
     try {
-      // Simulate loading delay
-      await new Promise((resolve) => setTimeout(resolve, 500))
+      const [chattersData, earningsData] = await Promise.all([
+        api.getChatters(),
+        api.getEmployeeEarnings(),
+      ])
 
-      const existingChatters = JSON.parse(localStorage.getItem("chatters") || "[]")
-
-      // Calculate real earnings for each chatter
-      const earningsData = JSON.parse(localStorage.getItem("employee_earnings") || "[]")
       const today = new Date().toISOString().split("T")[0]
       const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split("T")[0]
 
-      const chattersWithRealEarnings = existingChatters.map((chatter: Chatter) => {
-        const chatterEarnings = earningsData.filter((e: any) => e.chatter_id === chatter.id)
+      const chattersWithRealEarnings = (chattersData || []).map((chatter: any) => {
+        const chatterEarnings = (earningsData || []).filter((e: any) => String(e.chatter_id) === String(chatter.id))
 
         const todayEarnings = chatterEarnings
           .filter((e: any) => e.date === today)
-          .reduce((sum: number, e: any) => sum + e.amount, 0)
+          .reduce((sum: number, e: any) => sum + (e.amount || 0), 0)
 
         const weekEarnings = chatterEarnings
           .filter((e: any) => e.date >= oneWeekAgo)
-          .reduce((sum: number, e: any) => sum + e.amount, 0)
+          .reduce((sum: number, e: any) => sum + (e.amount || 0), 0)
 
         return {
-          ...chatter,
+          id: String(chatter.id),
+          full_name: chatter.full_name || chatter.name || chatter.username || "Unknown",
+          email: chatter.email || "",
+          created_at: chatter.created_at,
+          isOnline: Math.random() > 0.6,
           todayEarnings,
           weekEarnings,
-          isOnline: Math.random() > 0.6, // Simple online status simulation
-          status: chatter.status || "active", // Default to active if not set
+          currency: chatter.currency || chatter.currency_symbol || "€",
+          commission_rate: chatter.commission_rate || chatter.commissionRate || 0,
+          platform_fee: chatter.platform_fee || chatter.platformFeeRate || 0,
+          status: chatter.status || "active",
         }
       })
 
-      console.log(
-        "[v0] Real chatters loaded:",
-        chattersWithRealEarnings.map((c) => ({ id: c.id, name: c.full_name, email: c.email, status: c.status })),
-      )
       setChatters(chattersWithRealEarnings)
     } catch (error) {
       console.error("Error fetching chatters:", error)
@@ -121,33 +122,19 @@ export function ChattersList() {
   const handleAddChatter = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
-      const newChatterId = Date.now().toString()
-      const chatterData = {
-        id: newChatterId,
-        full_name: newChatter.full_name,
-        email: newChatter.email,
-        created_at: new Date().toISOString(),
-        isOnline: false,
-        todayEarnings: 0,
-        weekEarnings: 0,
-        currency: newChatter.currency,
-        commission_rate: parseDecimalInput(newChatter.commission_rate),
-        platform_fee: parseDecimalInput(newChatter.platform_fee),
-        status: "active",
-      }
-
-      const existingChatters = JSON.parse(localStorage.getItem("chatters") || "[]")
-      const updatedChatters = [...existingChatters, chatterData]
-      localStorage.setItem("chatters", JSON.stringify(updatedChatters))
-
-      // Also store login credentials
-      const credentials = JSON.parse(localStorage.getItem("chatter_credentials") || "{}")
-      credentials[newChatter.email] = {
+      const user = await api.createUser({
+        username: newChatter.email,
         password: newChatter.password,
-        id: newChatterId,
         role: "chatter",
-      }
-      localStorage.setItem("chatter_credentials", JSON.stringify(credentials))
+        fullName: newChatter.full_name,
+      })
+
+      await api.createChatter({
+        userId: user.id,
+        currency: newChatter.currency,
+        commissionRate: parseDecimalInput(newChatter.commission_rate),
+        platformFeeRate: parseDecimalInput(newChatter.platform_fee),
+      })
 
       setNewChatter({
         full_name: "",
@@ -166,11 +153,9 @@ export function ChattersList() {
 
   const handleToggleStatus = async (chatterId: string, currentStatus: string) => {
     try {
-      const existingChatters = JSON.parse(localStorage.getItem("chatters") || "[]")
-      const updatedChatters = existingChatters.map((chatter: Chatter) =>
-        chatter.id === chatterId ? { ...chatter, status: currentStatus === "active" ? "inactive" : "active" } : chatter,
-      )
-      localStorage.setItem("chatters", JSON.stringify(updatedChatters))
+      await api.updateChatter(chatterId, {
+        status: currentStatus === "active" ? "inactive" : "active",
+      })
       fetchChatters()
     } catch (error) {
       console.error("Error toggling chatter status:", error)
@@ -179,21 +164,7 @@ export function ChattersList() {
 
   const handleDeleteChatter = async (chatterId: string, email: string) => {
     try {
-      // Remove from chatters list
-      const existingChatters = JSON.parse(localStorage.getItem("chatters") || "[]")
-      const updatedChatters = existingChatters.filter((chatter: Chatter) => chatter.id !== chatterId)
-      localStorage.setItem("chatters", JSON.stringify(updatedChatters))
-
-      // Remove credentials
-      const credentials = JSON.parse(localStorage.getItem("chatter_credentials") || "{}")
-      delete credentials[email]
-      localStorage.setItem("chatter_credentials", JSON.stringify(credentials))
-
-      // Remove earnings data
-      const earningsData = JSON.parse(localStorage.getItem("employee_earnings") || "[]")
-      const updatedEarnings = earningsData.filter((earning: any) => earning.chatter_id !== chatterId)
-      localStorage.setItem("employee_earnings", JSON.stringify(updatedEarnings))
-
+      await api.deleteChatter(chatterId)
       fetchChatters()
     } catch (error) {
       console.error("Error deleting chatter:", error)

--- a/components/commission-calculator.tsx
+++ b/components/commission-calculator.tsx
@@ -15,6 +15,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Calculator, DollarSign, Calendar, CheckCircle, Clock, XCircle } from "lucide-react"
+import { api } from "@/lib/api"
 
 interface Commission {
   id: string
@@ -56,56 +57,49 @@ export function CommissionCalculator() {
 
   const fetchCommissions = async () => {
     try {
-      // Mock commission data
-      const mockCommissions: Commission[] = [
-        {
-          id: "1",
-          user_id: "user1",
-          period_start: "2024-08-01",
-          period_end: "2024-08-15",
-          total_earnings: 2500,
-          commission_rate: 0.08,
-          commission_amount: 160,
-          status: "paid",
-          created_at: "2024-08-16T00:00:00Z",
-          chatter: {
-            full_name: "Emma Johnson",
-            currency: "€",
-          },
-        },
-        {
-          id: "2",
-          user_id: "user2",
-          period_start: "2024-08-01",
-          period_end: "2024-08-15",
-          total_earnings: 1800,
-          commission_rate: 0.1,
-          commission_amount: 144,
-          status: "pending",
-          created_at: "2024-08-16T00:00:00Z",
-          chatter: {
-            full_name: "Sarah Wilson",
-            currency: "$",
-          },
-        },
-        {
-          id: "3",
-          user_id: "user3",
-          period_start: "2024-07-16",
-          period_end: "2024-07-31",
-          total_earnings: 3200,
-          commission_rate: 0.08,
-          commission_amount: 204.8,
-          status: "paid",
-          created_at: "2024-08-01T00:00:00Z",
-          chatter: {
-            full_name: "Lisa Chen",
-            currency: "€",
-          },
-        },
-      ]
+      const [earningsData, chattersData] = await Promise.all([
+        api.getEmployeeEarnings(),
+        api.getChatters(),
+      ])
 
-      setCommissions(mockCommissions)
+      const currentDate = new Date()
+      const start = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1)
+      const end = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 0)
+      const periodStart = start.toISOString().split("T")[0]
+      const periodEnd = end.toISOString().split("T")[0]
+
+      const calculated: Commission[] = []
+
+      ;(chattersData || []).forEach((chatter: any) => {
+        const chatterEarnings = (earningsData || []).filter(
+          (e: any) => String(e.chatter_id) === String(chatter.id),
+        )
+        const totalEarnings = chatterEarnings.reduce(
+          (sum: number, e: any) => sum + (e.amount || 0),
+          0,
+        )
+        if (totalEarnings > 0) {
+          const rate = (chatter.commission_rate || chatter.commissionRate || 0) / 100
+          const commissionAmount = totalEarnings * rate
+          calculated.push({
+            id: String(chatter.id),
+            user_id: String(chatter.id),
+            period_start: periodStart,
+            period_end: periodEnd,
+            total_earnings: totalEarnings,
+            commission_rate: rate,
+            commission_amount: commissionAmount,
+            status: "calculated",
+            created_at: new Date().toISOString(),
+            chatter: {
+              full_name: chatter.full_name || chatter.name || chatter.username,
+              currency: chatter.currency || "€",
+            },
+          })
+        }
+      })
+
+      setCommissions(calculated)
     } catch (error) {
       console.error("Error fetching commissions:", error)
     } finally {
@@ -152,53 +146,42 @@ export function CommissionCalculator() {
 
     setCalculating(true)
     try {
-      // Mock chatter data with individual settings
-      const mockChatters = [
-        {
-          id: "user1",
-          full_name: "Emma Johnson",
-          currency: "€",
-          commission_rate: 8.0,
-          platform_fee_rate: 20.0,
-        },
-        {
-          id: "user2",
-          full_name: "Sarah Wilson",
-          currency: "$",
-          commission_rate: 10.0,
-          platform_fee_rate: 15.0,
-        },
-        {
-          id: "user3",
-          full_name: "Lisa Chen",
-          currency: "€",
-          commission_rate: 8.0,
-          platform_fee_rate: 20.0,
-        },
-      ]
+      const [startDate, endDate] = selectedPeriod.split("_")
+      const [earningsData, chattersData] = await Promise.all([
+        api.getEmployeeEarnings(),
+        api.getChatters(),
+      ])
 
       const calculations: ChatterEarnings[] = []
 
-      for (const chatter of mockChatters) {
-        // Mock earnings for the selected period
-        const totalEarnings = Math.floor(Math.random() * 3000) + 1000 // Random earnings between 1000-4000
-
-        const platformFeeAmount = totalEarnings * (chatter.platform_fee_rate / 100)
-        const netEarnings = totalEarnings - platformFeeAmount
-        const commissionAmount = netEarnings * (chatter.commission_rate / 100)
-
+      ;(chattersData || []).forEach((chatter: any) => {
+        const chatterEarnings = (earningsData || []).filter(
+          (e: any) =>
+            String(e.chatter_id) === String(chatter.id) &&
+            e.date >= startDate &&
+            e.date <= endDate,
+        )
+        const totalEarnings = chatterEarnings.reduce(
+          (sum: number, e: any) => sum + (e.amount || 0),
+          0,
+        )
         if (totalEarnings > 0) {
+          const commissionRate = chatter.commission_rate || chatter.commissionRate || 0
+          const platformFeeRate = chatter.platform_fee || chatter.platformFeeRate || 0
+          const platformFeeAmount = totalEarnings * (platformFeeRate / 100)
+          const netEarnings = totalEarnings - platformFeeAmount
+          const commissionAmount = netEarnings * (commissionRate / 100)
           calculations.push({
-            chatter_id: chatter.id,
-            full_name: chatter.full_name,
-            currency: chatter.currency,
-            commission_rate: chatter.commission_rate,
-            platform_fee_rate: chatter.platform_fee_rate,
+            chatter_id: String(chatter.id),
+            full_name: chatter.full_name || chatter.name || chatter.username,
+            currency: chatter.currency || "€",
+            commission_rate: commissionRate,
+            platform_fee_rate: platformFeeRate,
             total_earnings: totalEarnings,
             commission_amount: commissionAmount,
           })
         }
-      }
+      })
 
       setPendingCalculations(calculations)
       setIsCalculateDialogOpen(true)

--- a/components/create-chatter-form.tsx
+++ b/components/create-chatter-form.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { toast } from "@/hooks/use-toast"
+import { api } from "@/lib/api"
 
 export function CreateChatterForm() {
   const [username, setUsername] = useState("")
@@ -34,25 +35,18 @@ export function CreateChatterForm() {
     setIsLoading(true)
 
     try {
-      const response = await fetch("/api/create-chatter", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username,
-          password,
-          currency,
-          commissionRate: parseDecimalInput(commissionRate),
-          platformFeeRate: parseDecimalInput(platformFeeRate),
-        }),
+      const createdUser = await api.createUser({
+        username,
+        password,
+        role: "chatter",
       })
 
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to create chatter account")
-      }
+      await api.createChatter({
+        userId: createdUser.id,
+        currency,
+        commissionRate: parseDecimalInput(commissionRate),
+        platformFeeRate: parseDecimalInput(platformFeeRate),
+      })
 
       toast({
         title: "Success",
@@ -65,10 +59,10 @@ export function CreateChatterForm() {
       setCurrency("€")
       setCommissionRate("8,00")
       setPlatformFeeRate("20,00")
-    } catch (error) {
+    } catch (error: any) {
       toast({
         title: "Error",
-        description: error instanceof Error ? error.message : "Failed to create account",
+        description: error?.message || "Failed to create account",
         variant: "destructive",
       })
     } finally {

--- a/components/earnings-overview.tsx
+++ b/components/earnings-overview.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
 import { DollarSign, Calendar, User } from "lucide-react"
+import { api } from "@/lib/api"
 
 interface EarningsOverviewProps {
   limit?: number
@@ -32,60 +33,50 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
 
   const fetchEarnings = async () => {
     try {
-      const storedEarnings = JSON.parse(localStorage.getItem("employee_earnings") || "[]")
-      const storedChatters = JSON.parse(localStorage.getItem("chatters") || "[]")
-
-      console.log("[v0] Earnings Overview: Raw earnings data:", storedEarnings)
-      console.log("[v0] Earnings Overview: Active chatters:", storedChatters)
+      const [earningsData, chattersData] = await Promise.all([
+        api.getEmployeeEarnings(),
+        api.getChatters(),
+      ])
 
       const activeChattersMap = new Map()
-      storedChatters.forEach((chatter: any) => {
-        // Use full_name instead of name for consistency
-        activeChattersMap.set(chatter.id, chatter.full_name || chatter.name)
+      ;(chattersData || []).forEach((chatter: any) => {
+        activeChattersMap.set(String(chatter.id), chatter.full_name || chatter.name || chatter.username)
       })
 
-      const validEarnings = storedEarnings.filter((earning: any) => activeChattersMap.has(earning.chatter_id))
+      const validEarnings = (earningsData || []).filter((earning: any) =>
+        activeChattersMap.has(String(earning.chatter_id)),
+      )
 
-      if (validEarnings.length !== storedEarnings.length) {
-        console.log("[v0] Earnings Overview: Cleaning up orphaned earnings data")
-        localStorage.setItem("employee_earnings", JSON.stringify(validEarnings))
-      }
-
-      // Format earnings with active chatters only
       const formattedEarnings = validEarnings
         .map((earning: any) => ({
-          id: earning.id,
+          id: String(earning.id),
           date: earning.date,
           amount: earning.amount,
           description: earning.description,
           chatter: {
-            full_name: activeChattersMap.get(earning.chatter_id),
+            full_name: activeChattersMap.get(String(earning.chatter_id)),
           },
         }))
         .sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime())
 
-      console.log("[v0] Earnings Overview: Formatted earnings:", formattedEarnings)
-
-      // Apply limit if specified
       const limitedEarnings = limit ? formattedEarnings.slice(0, limit) : formattedEarnings
       setEarnings(limitedEarnings)
 
-      // Calculate totals with real data
       const today = new Date().toISOString().split("T")[0]
-      const todayEarnings = formattedEarnings.filter((e: any) => e.date === today)
-      const todayTotal = todayEarnings.reduce((sum: number, e: any) => sum + e.amount, 0)
+      const todayTotal = formattedEarnings
+        .filter((e: any) => e.date === today)
+        .reduce((sum: number, e: any) => sum + (e.amount || 0), 0)
 
       const weekStart = new Date()
       weekStart.setDate(weekStart.getDate() - weekStart.getDay())
       const weekStartStr = weekStart.toISOString().split("T")[0]
 
-      const weekEarnings = formattedEarnings.filter((e: any) => e.date >= weekStartStr)
-      const weekTotal = weekEarnings.reduce((sum: number, e: any) => sum + e.amount, 0)
+      const weekTotal = formattedEarnings
+        .filter((e: any) => e.date >= weekStartStr)
+        .reduce((sum: number, e: any) => sum + (e.amount || 0), 0)
 
       setTotalToday(todayTotal)
       setTotalWeek(weekTotal)
-
-      console.log("[v0] Earnings Overview: Today total:", todayTotal, "Week total:", weekTotal)
     } catch (error) {
       console.error("Error fetching earnings:", error)
     } finally {

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Trophy, Medal, Award, DollarSign } from "lucide-react"
+import { api } from "@/lib/api"
 
 interface LeaderboardEntry {
   id: string
@@ -29,55 +30,50 @@ export function Leaderboard({ limit, refreshTrigger }: LeaderboardProps) {
 
   const fetchLeaderboard = async () => {
     try {
-      console.log("[v0] Leaderboard: Fetching data from localStorage")
+      const [chattersData, earningsData] = await Promise.all([
+        api.getChatters(),
+        api.getEmployeeEarnings(),
+      ])
 
-      const chattersData = localStorage.getItem("chatters")
-      const allChatters = chattersData ? JSON.parse(chattersData) : []
-
-      const activeChatters = allChatters.filter((chatter: any) => chatter.status !== "inactive")
-
-      // Get earnings data from localStorage
-      const earningsData = localStorage.getItem("employee_earnings")
-      const allEarnings = earningsData ? JSON.parse(earningsData) : []
-
-      console.log("[v0] Leaderboard: Active chatters:", activeChatters)
-      console.log("[v0] Leaderboard: All earnings:", allEarnings)
+      const activeChatters = (chattersData || []).filter((chatter: any) => chatter.status !== "inactive")
 
       const leaderboardData: LeaderboardEntry[] = activeChatters.map((chatter: any) => {
-        const chatterEarnings = allEarnings.filter((earning: any) => earning.chatter_id === chatter.id)
+        const chatterEarnings = (earningsData || []).filter(
+          (earning: any) => String(earning.chatter_id) === String(chatter.id),
+        )
 
         const now = new Date()
-        const startOfWeek = new Date(now.setDate(now.getDate() - now.getDay()))
+        const startOfWeek = new Date(now)
+        startOfWeek.setDate(now.getDate() - now.getDay())
         const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
 
         const weekEarnings = chatterEarnings
           .filter((earning: any) => new Date(earning.date) >= startOfWeek)
-          .reduce((sum: number, earning: any) => sum + earning.amount, 0)
+          .reduce((sum: number, earning: any) => sum + (earning.amount || 0), 0)
 
         const monthEarnings = chatterEarnings
           .filter((earning: any) => new Date(earning.date) >= startOfMonth)
-          .reduce((sum: number, earning: any) => sum + earning.amount, 0)
+          .reduce((sum: number, earning: any) => sum + (earning.amount || 0), 0)
 
-        const totalEarnings = chatterEarnings.reduce((sum: number, earning: any) => sum + earning.amount, 0)
+        const totalEarnings = chatterEarnings.reduce(
+          (sum: number, earning: any) => sum + (earning.amount || 0),
+          0,
+        )
 
         return {
-          id: chatter.id,
-          full_name: chatter.name || chatter.full_name || `User ${chatter.id}`,
+          id: String(chatter.id),
+          full_name: chatter.full_name || chatter.name || chatter.username || `User ${chatter.id}`,
           total_earnings: totalEarnings,
           week_earnings: weekEarnings,
           month_earnings: monthEarnings,
-          rank: 0, // Will be set after sorting
+          rank: 0,
         }
       })
 
-      // Sort by month earnings (descending) and assign ranks
       const sortedData = leaderboardData
         .sort((a, b) => b.month_earnings - a.month_earnings)
         .map((entry, index) => ({ ...entry, rank: index + 1 }))
 
-      console.log("[v0] Leaderboard: Sorted data:", sortedData)
-
-      // Apply limit if specified
       const limitedData = limit ? sortedData.slice(0, limit) : sortedData
       setLeaderboard(limitedData)
     } catch (error) {

--- a/components/setup-manager.tsx
+++ b/components/setup-manager.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { useState } from "react"
+import { api } from "@/lib/api"
 
 export function SetupManager() {
   const [isLoading, setIsLoading] = useState(false)
@@ -15,21 +16,18 @@ export function SetupManager() {
     setMessage(null)
 
     try {
-      const response = await fetch("/api/create-manager", {
-        method: "POST",
+      await api.createUser({
+        username: "WolfMas",
+        password: "WolfMas0904",
+        fullName: "WolfMas",
+        role: "manager",
       })
 
-      const data = await response.json()
-
-      if (response.ok) {
-        setMessage(
-          "Manager account created successfully! You can now login with username: WolfMas and password: WolfMas0904",
-        )
-      } else {
-        setError(data.error || "Failed to create manager account")
-      }
-    } catch (error) {
-      setError("Network error occurred")
+      setMessage(
+        "Manager account created successfully! You can now login with username: WolfMas and password: WolfMas0904",
+      )
+    } catch (error: any) {
+      setError(error?.message || "Failed to create manager account")
     } finally {
       setIsLoading(false)
     }

--- a/components/weekly-calendar.tsx
+++ b/components/weekly-calendar.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { ChevronLeft, ChevronRight, Clock, User } from "lucide-react"
+import { api } from "@/lib/api"
 
 interface Shift {
   id: string
@@ -48,29 +49,33 @@ export function WeeklyCalendar({
     return week
   }
 
-  const fetchShifts = () => {
+  const fetchShifts = async () => {
     try {
-      const shiftsData = JSON.parse(localStorage.getItem("shifts") || "[]")
-      const chattersData = JSON.parse(localStorage.getItem("chatters") || "[]")
+      const [shiftsData, chattersData] = await Promise.all([
+        api.getShifts(),
+        api.getChatters(),
+      ])
 
-      // Create a map of chatter IDs to names
-      const chatterMap = chattersData.reduce((acc: any, chatter: any) => {
-        acc[chatter.id] = chatter.full_name || chatter.name
-        return acc
-      }, {})
+      const chatterMap: Record<string, string> = {}
+      ;(chattersData || []).forEach((chatter: any) => {
+        chatterMap[String(chatter.id)] = chatter.full_name || chatter.name || chatter.username
+      })
 
-      const formattedShifts = shiftsData.map((shift: any) => ({
-        ...shift,
-        chatter_name: chatterMap[shift.chatter_id] || "Unknown Chatter",
+      const formattedShifts = (shiftsData || []).map((shift: any) => ({
+        id: String(shift.id),
+        chatter_id: String(shift.chatter_id),
+        chatter_name: chatterMap[String(shift.chatter_id)] || "Unknown Chatter",
+        date: shift.start_time ? shift.start_time.split("T")[0] : shift.date,
+        start_time: shift.start_time ? shift.start_time.substring(11, 16) : shift.start_time,
+        end_time: shift.end_time ? shift.end_time.substring(11, 16) : shift.end_time,
+        status: shift.status,
       }))
 
-      // Filter by user if userId is provided
       const filteredShifts = userId
-        ? formattedShifts.filter((shift: Shift) => shift.chatter_id === userId)
+        ? formattedShifts.filter((shift: Shift) => shift.chatter_id === String(userId))
         : formattedShifts
 
       setShifts(filteredShifts)
-      console.log("[v0] WeeklyCalendar: Loaded shifts:", filteredShifts)
     } catch (error) {
       console.error("[v0] WeeklyCalendar: Error loading shifts:", error)
       setShifts([])


### PR DESCRIPTION
## Summary
- route manager setup through centralized API client
- create chatter accounts using API client instead of direct fetch
- load manager dashboard data from backend instead of local mocks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adce2c5284832798b2f2384fd5a5bc