### PR TITLE
fix: guard client pages and shift manager data

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -30,7 +30,8 @@ export default function LoginPage() {
       document.cookie = "user-session=logged-in; path=/; max-age=86400; samesite=lax"
 
       // Use returned user (preferred) or fall back to what ApiClient stored
-      const user = result?.user ?? JSON.parse(localStorage.getItem("user") || "null")
+      const stored = typeof window !== "undefined" ? localStorage.getItem("user") : null
+      const user = result?.user ?? (stored ? JSON.parse(stored) : null)
 
       if (user?.role === "manager") {
         router.push("/manager")

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -12,6 +12,8 @@ export default function DashboardPage() {
   useEffect(() => {
     console.log("[v0] Dashboard: Checking authentication")
 
+    if (typeof window === "undefined") return
+
     // Check localStorage for user session
     const userSession = localStorage.getItem("user")
     console.log("[v0] Dashboard: User session found:", !!userSession)
@@ -26,22 +28,22 @@ export default function DashboardPage() {
           setIsAuthenticated(true)
         } else {
           console.log("[v0] Dashboard: User is not a chatter, redirecting to login")
-          window.location.href = "/auth/login"
+          router.replace("/auth/login")
           return
         }
       } catch (error) {
         console.log("[v0] Dashboard: Error parsing user session:", error)
-        window.location.href = "/auth/login"
+        router.replace("/auth/login")
         return
       }
     } else {
       console.log("[v0] Dashboard: No user session found, redirecting to login")
-      window.location.href = "/auth/login"
+      router.replace("/auth/login")
       return
     }
 
     setIsLoading(false)
-  }, [])
+  }, [router])
 
   if (isLoading) {
     return (

--- a/app/manager/page.tsx
+++ b/app/manager/page.tsx
@@ -1,16 +1,22 @@
 "use client"
 
 import { useEffect } from "react"
+import { useRouter } from "next/navigation"
 import { ManagerDashboard } from "@/components/manager-dashboard"
 
 export default function ManagerPage() {
+  const router = useRouter()
+
   useEffect(() => {
     console.log("[v0] Manager page loaded, checking authentication")
+
+    if (typeof window === "undefined") return
+
     const userStr = localStorage.getItem("user")
 
     if (!userStr) {
       console.log("[v0] No user found in localStorage, redirecting to login")
-      window.location.href = "/auth/login"
+      router.replace("/auth/login")
       return
     }
 
@@ -19,16 +25,16 @@ export default function ManagerPage() {
       console.log("[v0] Parsed user data:", user)
       if (user.role !== "manager") {
         console.log("[v0] User is not a manager, redirecting to login")
-        window.location.href = "/auth/login"
+        router.replace("/auth/login")
         return
       }
       console.log("[v0] Manager authenticated successfully")
     } catch (error) {
       console.log("[v0] Error parsing user data:", error)
-      window.location.href = "/auth/login"
+      router.replace("/auth/login")
       return
     }
-  }, [])
+  }, [router])
 
   return <ManagerDashboard />
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,8 @@ export default function HomePage() {
   const router = useRouter()
 
   useEffect(() => {
+    if (typeof window === "undefined") return
+
     const isLoggedIn = localStorage.getItem("isLoggedIn")
     const userRole = localStorage.getItem("userRole")
 

--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -17,6 +17,8 @@ export function AuthGuard({ children, requiredRole }: AuthGuardProps) {
   useEffect(() => {
     const checkAuth = () => {
       try {
+        if (typeof window === "undefined") return
+
         const isLoggedIn = localStorage.getItem("user-session") === "logged-in"
         const userRole = localStorage.getItem("user-role") || "chatter"
 

--- a/components/chatters-list.tsx
+++ b/components/chatters-list.tsx
@@ -77,6 +77,11 @@ export function ChattersList() {
 
   const fetchChatters = async () => {
     try {
+      const [chattersData, earningsData] = await Promise.all([
+        api.getChatters(),
+        api.getEmployeeEarnings(),
+      ])
+
       const today = new Date().toISOString().split("T")[0]
       const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split("T")[0]
 

--- a/components/commission-calculator.tsx
+++ b/components/commission-calculator.tsx
@@ -57,6 +57,11 @@ export function CommissionCalculator() {
 
   const fetchCommissions = async () => {
     try {
+      const [earningsData, chattersData] = await Promise.all([
+        api.getEmployeeEarnings(),
+        api.getChatters(),
+      ])
+
       const currentDate = new Date()
       const start = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1)
       const end = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 0)
@@ -87,6 +92,7 @@ export function CommissionCalculator() {
             status: "calculated",
             created_at: new Date().toISOString(),
             chatter: {
+              full_name: chatter.full_name,
               currency: chatter.currency || "€",
             },
           })
@@ -141,6 +147,15 @@ export function CommissionCalculator() {
     setCalculating(true)
     try {
       const [startDate, endDate] = selectedPeriod.split("_")
+
+      const [earningsData, chattersData] = await Promise.all([
+        api.getEmployeeEarnings(),
+        api.getChatters(),
+      ])
+
+      const calculations: ChatterEarnings[] = []
+
+      ;(chattersData || []).forEach((chatter: any) => {
         const chatterEarnings = (earningsData || []).filter(
           (e: any) =>
             String(e.chatter_id) === String(chatter.id) &&
@@ -159,6 +174,7 @@ export function CommissionCalculator() {
           const commissionAmount = netEarnings * (commissionRate / 100)
           calculations.push({
             chatter_id: String(chatter.id),
+            full_name: chatter.full_name,
             currency: chatter.currency || "€",
             commission_rate: commissionRate,
             platform_fee_rate: platformFeeRate,

--- a/components/earnings-overview.tsx
+++ b/components/earnings-overview.tsx
@@ -33,7 +33,16 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
 
   const fetchEarnings = async () => {
     try {
-      })
+      const [earningsData, chattersData] = await Promise.all([
+        api.getEmployeeEarnings(),
+        api.getChatters(),
+      ])
+
+      const activeChattersMap = new Map(
+        (chattersData || [])
+          .filter((ch: any) => ch.status !== "inactive")
+          .map((ch: any) => [String(ch.id), ch.full_name]),
+      )
 
       const validEarnings = (earningsData || []).filter((earning: any) =>
         activeChattersMap.has(String(earning.chatter_id)),

--- a/components/employee-dashboard.tsx
+++ b/components/employee-dashboard.tsx
@@ -26,6 +26,7 @@ export function EmployeeDashboard() {
     let cancelled = false
 
     const bootstrap = async () => {
+      if (typeof window === "undefined") return
       try {
         // Require token + stored user id (set by api.login)
         const token = localStorage.getItem("auth_token")

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -30,6 +30,12 @@ export function Leaderboard({ limit, refreshTrigger }: LeaderboardProps) {
 
   const fetchLeaderboard = async () => {
     try {
+      const [earningsData, chattersData] = await Promise.all([
+        api.getEmployeeEarnings(),
+        api.getChatters(),
+      ])
+
+      const leaderboardData = (chattersData || []).map((chatter: any) => {
         const chatterEarnings = (earningsData || []).filter(
           (earning: any) => String(earning.chatter_id) === String(chatter.id),
         )
@@ -54,6 +60,7 @@ export function Leaderboard({ limit, refreshTrigger }: LeaderboardProps) {
 
         return {
           id: String(chatter.id),
+          full_name: chatter.full_name,
           total_earnings: totalEarnings,
           week_earnings: weekEarnings,
           month_earnings: monthEarnings,

--- a/components/manager-dashboard.tsx
+++ b/components/manager-dashboard.tsx
@@ -50,6 +50,7 @@ export function ManagerDashboard() {
     let cancelled = false
 
     const bootstrap = async () => {
+      if (typeof window === "undefined") return
       try {
         console.log("[manager] bootstrap start")
 

--- a/components/shift-manager.tsx
+++ b/components/shift-manager.tsx
@@ -59,6 +59,13 @@ export function ShiftManager() {
 
   const fetchData = async () => {
     try {
+      const [shiftsData, chattersData] = await Promise.all([
+        api.getShifts(),
+        api.getChatters(),
+      ])
+
+      const chatterMap = new Map(
+        (chattersData || []).map((c: any) => [String(c.id), c.full_name])
       )
 
       const formattedShifts = (shiftsData || []).map((shift: any) => ({
@@ -73,6 +80,10 @@ export function ShiftManager() {
 
       setShifts(formattedShifts)
       setChatters(
+        (chattersData || []).map((c: any) => ({
+          id: String(c.id),
+          full_name: c.full_name,
+        }))
       )
     } catch (error) {
       console.error("Error fetching shifts:", error)

--- a/components/weekly-calendar.tsx
+++ b/components/weekly-calendar.tsx
@@ -49,30 +49,38 @@ export function WeeklyCalendar({
     return week
   }
 
-  const fetchShifts = async () => {
-    try {
-      })
+    const fetchShifts = async () => {
+      try {
+        const [shiftsData, chattersData] = await Promise.all([
+          api.getShifts(),
+          api.getChatters(),
+        ])
 
-      const formattedShifts = (shiftsData || []).map((shift: any) => ({
-        id: String(shift.id),
-        chatter_id: String(shift.chatter_id),
-        chatter_name: chatterMap[String(shift.chatter_id)] || "Unknown Chatter",
-        date: shift.start_time ? shift.start_time.split("T")[0] : shift.date,
-        start_time: shift.start_time ? shift.start_time.substring(11, 16) : shift.start_time,
-        end_time: shift.end_time ? shift.end_time.substring(11, 16) : shift.end_time,
-        status: shift.status,
-      }))
+        const chatterMap: Record<string, string> = {}
+        ;(chattersData || []).forEach((chatter: any) => {
+          chatterMap[String(chatter.id)] = chatter.full_name
+        })
 
-      const filteredShifts = userId
-        ? formattedShifts.filter((shift: Shift) => shift.chatter_id === String(userId))
-        : formattedShifts
+        const formattedShifts = (shiftsData || []).map((shift: any) => ({
+          id: String(shift.id),
+          chatter_id: String(shift.chatter_id),
+          chatter_name: chatterMap[String(shift.chatter_id)] || "Unknown Chatter",
+          date: shift.start_time ? shift.start_time.split("T")[0] : shift.date,
+          start_time: shift.start_time ? shift.start_time.substring(11, 16) : shift.start_time,
+          end_time: shift.end_time ? shift.end_time.substring(11, 16) : shift.end_time,
+          status: shift.status,
+        }))
 
-      setShifts(filteredShifts)
-    } catch (error) {
-      console.error("[v0] WeeklyCalendar: Error loading shifts:", error)
-      setShifts([])
-    } finally {
-      setLoading(false)
+        const filteredShifts = userId
+          ? formattedShifts.filter((shift: Shift) => shift.chatter_id === String(userId))
+          : formattedShifts
+
+        setShifts(filteredShifts)
+      } catch (error) {
+        console.error("[v0] WeeklyCalendar: Error loading shifts:", error)
+        setShifts([])
+      } finally {
+        setLoading(false)
     }
   }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -4,6 +4,7 @@ const API_BASE_URL =
 
 class ApiClient {
   private getAuthHeaders(): Record<string, string> {
+    if (typeof window === "undefined") return {}
     const token = localStorage.getItem("auth_token")
     return token ? { Authorization: `Bearer ${token}` } : {}
   }


### PR DESCRIPTION
## Summary
- guard window access before using localStorage in client pages and dashboards
- use Next.js router instead of `window.location` for redirects
- load chatter, earnings, shift, and commission data via API in client components
- fetch shifts and chatter names together in shift manager

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68add95a1e248327ad248489ef819616