### PR TITLE
feat: save commissions to backend

### DIFF
--- a/components/commission-calculator.tsx
+++ b/components/commission-calculator.tsx
@@ -226,7 +226,20 @@ export function CommissionCalculator() {
     try {
       const [startDate, endDate] = selectedPeriod.split("_")
 
-      // Mock saving - just add to existing commissions
+      await Promise.all(
+        pendingCalculations.map((calc) =>
+          api.createCommission({
+            chatterId: Number(calc.chatter_id),
+            periodStart: startDate,
+            periodEnd: endDate,
+            earnings: calc.total_earnings,
+            commissionRate: calc.commission_rate / 100,
+            commission: calc.commission_amount,
+            status: "pending",
+          }),
+        ),
+      )
+
       const newCommissions = pendingCalculations.map((calc, index) => ({
         id: `new_${Date.now()}_${index}`,
         user_id: calc.chatter_id,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -129,6 +129,14 @@ class ApiClient {
     return this.request(`/employee-earnings/${id}`, { method: "DELETE" })
   }
 
+  /* ---------- Commissions ---------- */
+  createCommission(data: any) {
+    return this.request("/commissions", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+  }
+
   /* ---------- Shifts ---------- */
   getShifts() {
     return this.request("/shifts")


### PR DESCRIPTION
## Summary
- save calculated commissions via new createCommission API call
- add API client method for creating commissions

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68adfcfdabac83279db74511ab47d0a9