### PR TITLE
feat: persist and manage commissions

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -129,6 +129,29 @@ class ApiClient {
     return this.request(`/employee-earnings/${id}`, { method: "DELETE" })
   }
 
+  /* ---------- Commissions ---------- */
+  getCommissions() {
+    return this.request("/commissions")
+  }
+
+  createCommission(data: any) {
+    return this.request("/commissions", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+  }
+
+  updateCommission(id: string, data: any) {
+    return this.request(`/commissions/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    })
+  }
+
+  deleteCommission(id: string) {
+    return this.request(`/commissions/${id}`, { method: "DELETE" })
+  }
+
   /* ---------- Shifts ---------- */
   getShifts() {
     return this.request("/shifts")


### PR DESCRIPTION
## Summary
- save calculated commissions via new createCommission API call
- load existing commissions when opening the calculator page
- add API client methods for creating, updating, and deleting commissions
- enable marking commissions as paid and removing them from the calculator

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*
- `npx tsc --noEmit` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68adfcfdabac83279db74511ab47d0a9