### PR TITLE
Wrap manager dashboard in suspense

### DIFF
--- a/app/manager/page.tsx
+++ b/app/manager/page.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { useEffect } from "react"
+import { Suspense, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { ManagerDashboard } from "@/components/manager-dashboard"
 
-export const dynamic = "force-dynamic";
+export const dynamic = "force-dynamic"
 
 export default function ManagerPage() {
   const router = useRouter()
@@ -38,5 +38,15 @@ export default function ManagerPage() {
     }
   }, [router])
 
-  return <ManagerDashboard />
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        </div>
+      }
+    >
+      <ManagerDashboard />
+    </Suspense>
+  )
 }


### PR DESCRIPTION
## Summary
- wrap `ManagerDashboard` in a `Suspense` boundary to safely use `useSearchParams` on `/manager`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed70619508327b1149b5a2a9df018