### PR TITLE
Add per-chatter unlock earnings view with F2F integration

### DIFF
--- a/app/api/f2f/unlocks/route.ts
+++ b/app/api/f2f/unlocks/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BASE = process.env.F2F_BASE || "https://f2f.com";
+const UA =
+  process.env.F2F_UA ||
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36";
+const COOKIES = process.env.F2F_COOKIES || "";
+
+const CREATORS_URL = `${BASE}/api/agency/creators/`;
+const CHATS_URL = `${BASE}/api/chats/?ordering=newest-first`;
+const CHAT_MESSAGES_URL = (chatId: string) => `${BASE}/api/chats/${chatId}/messages/`;
+
+function headersFor(creatorSlug?: string): Record<string, string> {
+  const h: Record<string, string> = {
+    accept: "application/json, text/plain, */*",
+    "accept-language": "nl-NL,nl;q=0.9,en-US;q=0.8,en;q=0.7",
+    "user-agent": UA,
+    cookie: COOKIES,
+    origin: BASE,
+    referer: `${BASE}/`,
+  };
+  if (creatorSlug) h["impersonate-user"] = creatorSlug;
+  return h;
+}
+
+async function fetchAllPages(startUrl: string, headers: Record<string, string>, label = "") {
+  let url: string | null = startUrl;
+  const all: any[] = [];
+  const seen = new Set<string>();
+
+  while (url) {
+    if (seen.has(url)) break;
+    seen.add(url);
+
+    const res = await fetch(url, { headers });
+    const ct = res.headers.get("content-type") || "";
+    const text = await res.text();
+    if (!res.ok || ct.includes("text/html")) {
+      throw new Error(`[${label}] Blocked/error ${res.status}. First 300 chars:\n${text.slice(0, 300)}`);
+    }
+    const page = JSON.parse(text);
+    const items = Array.isArray(page) ? page : page.results || [];
+    all.push(...items);
+    url = page.next || null;
+  }
+  return all;
+}
+
+async function getAllCreators() {
+  const creators = await fetchAllPages(CREATORS_URL, headersFor(), "creators");
+  const slugs = creators
+    .map((c: any) => c.username || c.slug || c.id || c.name)
+    .filter(Boolean);
+  return Array.from(new Set(slugs));
+}
+
+async function getAllChatsForCreator(creator: string, from: Date, to: Date) {
+  const chats = await fetchAllPages(CHATS_URL, headersFor(creator), `chats:${creator}`);
+  const inWindow = (iso?: string) => {
+    if (!iso) return false;
+    const d = new Date(iso);
+    return !Number.isNaN(d.getTime()) && d >= from && d <= to;
+  };
+  return chats
+    .filter((c: any) => inWindow(c.message?.datetime))
+    .map((c: any) => ({
+      id: c.uuid || c.id,
+      title: c.title || "",
+      username: c.other_user?.username || null,
+      lastMessageAt: c.message?.datetime || null,
+    }))
+    .filter((c: any) => !!c.id);
+}
+
+async function getAllMessagesForChat(creator: string, chatId: string) {
+  return fetchAllPages(CHAT_MESSAGES_URL(chatId), headersFor(creator), `msgs:${creator}:${chatId}`);
+}
+
+function pickUnlocksInWindow(messages: any[], from: Date, to: Date) {
+  return messages
+    .filter(
+      (m) =>
+        m.unlock &&
+        typeof m.unlock.price !== "undefined" &&
+        m.datetime &&
+        new Date(m.datetime) >= from &&
+        new Date(m.datetime) <= to,
+    )
+    .map((m) => ({ datetime: m.datetime, price: Number(m.unlock.price) || 0 }));
+}
+
+export async function GET(req: NextRequest) {
+  if (!COOKIES || COOKIES.includes("<PASTE")) {
+    return NextResponse.json({ error: "Missing F2F_COOKIES" }, { status: 500 });
+  }
+
+  const url = new URL(req.url);
+  const toParam = url.searchParams.get("to");
+  const fromParam = url.searchParams.get("from");
+  const to = toParam ? new Date(toParam) : new Date();
+  const from = fromParam ? new Date(fromParam) : new Date(to.getTime() - 24 * 60 * 60 * 1000);
+
+  const creators = await getAllCreators();
+  const rows: any[] = [];
+
+  for (const creator of creators) {
+    const chats = await getAllChatsForCreator(creator, from, to);
+    for (const chat of chats) {
+      const msgs = await getAllMessagesForChat(creator, chat.id);
+      const unlocks = pickUnlocksInWindow(msgs, from, to);
+      for (const u of unlocks) {
+        rows.push({
+          creator,
+          chatId: chat.id,
+          username: chat.username || chat.title || "",
+          datetime: u.datetime,
+          price: u.price,
+        });
+      }
+    }
+  }
+
+  return NextResponse.json({ from: from.toISOString(), to: to.toISOString(), rows });
+}
+

--- a/components/manager-dashboard.tsx
+++ b/components/manager-dashboard.tsx
@@ -19,7 +19,8 @@ import { CommissionCalculator } from "@/components/commission-calculator"
 import { Leaderboard } from "@/components/leaderboard"
 import { CreateChatterForm } from "@/components/create-chatter-form"
 import { WeeklyCalendar } from "@/components/weekly-calendar"
-import { Users, DollarSign, Calendar, TrendingUp, Award, Settings, UserPlus, RotateCcw, Shield } from "lucide-react"
+import { Users, DollarSign, Calendar, TrendingUp, Award, Settings, UserPlus, RotateCcw, Shield, LockOpen } from "lucide-react"
+import { UnlocksByChatter } from "@/components/unlocks-by-chatter"
 import Image from "next/image"
 
 import { api } from "@/lib/api"
@@ -234,7 +235,7 @@ export function ManagerDashboard() {
 
           {/* Tabs */}
           <Tabs value={activeTab} onValueChange={setActiveTab} defaultValue="overview" className="space-y-6">
-            <TabsList className="grid w-full grid-cols-7">
+            <TabsList className="grid w-full grid-cols-8">
               <TabsTrigger value="overview" className="flex items-center gap-2">
                 <TrendingUp className="h-4 w-4" />
                 Overview
@@ -250,6 +251,10 @@ export function ManagerDashboard() {
               <TabsTrigger value="earnings" className="flex items-center gap-2">
                 <DollarSign className="h-4 w-4" />
                 Earnings
+              </TabsTrigger>
+              <TabsTrigger value="unlocks" className="flex items-center gap-2">
+                <LockOpen className="h-4 w-4" />
+                Unlocks
               </TabsTrigger>
               <TabsTrigger value="shifts" className="flex items-center gap-2">
                 <Calendar className="h-4 w-4" />
@@ -361,6 +366,10 @@ export function ManagerDashboard() {
 
             <TabsContent value="earnings">
               <EarningsOverview />
+            </TabsContent>
+
+            <TabsContent value="unlocks">
+              <UnlocksByChatter />
             </TabsContent>
 
             <TabsContent value="shifts">

--- a/components/unlocks-by-chatter.tsx
+++ b/components/unlocks-by-chatter.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { DollarSign, User } from "lucide-react";
+import { api } from "@/lib/api";
+
+interface UnlockRow {
+  creator: string;
+  chatId: string;
+  username: string;
+  datetime: string;
+  price: number;
+}
+
+interface Shift {
+  id: string;
+  chatterId: string;
+  startTime: string;
+  endTime: string;
+}
+
+export function UnlocksByChatter() {
+  const [totals, setTotals] = useState<Record<string, number>>({});
+  const [names, setNames] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [unlockRes, shiftsData, chattersData, usersData] = await Promise.all([
+          fetch("/api/f2f/unlocks").then((r) => r.json()),
+          api.getShifts(),
+          api.getChatters(),
+          api.getUsers(),
+        ]);
+
+        const userMap = new Map((usersData || []).map((u: any) => [String(u.id), u.fullName || ""]));
+        const chatterNameMap = new Map(
+          (chattersData || []).map((c: any) => [String(c.id), userMap.get(String(c.id)) || ""]),
+        );
+
+        const shifts: Shift[] = (shiftsData || []).map((s: any) => ({
+          id: String(s.id),
+          chatterId: String(s.chatterId),
+          startTime: s.startTime,
+          endTime: s.endTime,
+        }));
+
+        const totalsByChatter: Record<string, number> = {};
+
+        (unlockRes.rows || []).forEach((u: UnlockRow) => {
+          const dt = new Date(u.datetime);
+          const shift = shifts.find(
+            (sh) => dt >= new Date(sh.startTime) && dt <= new Date(sh.endTime),
+          );
+          if (shift?.chatterId) {
+            totalsByChatter[shift.chatterId] = (totalsByChatter[shift.chatterId] || 0) + u.price;
+          }
+        });
+
+        setTotals(totalsByChatter);
+        const nameMap: Record<string, string> = {};
+        chatterNameMap.forEach((n, id) => {
+          nameMap[id] = n;
+        });
+        setNames(nameMap);
+      } catch (err) {
+        console.error("Error loading unlocks", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, []);
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat("nl-NL", { style: "currency", currency: "EUR" }).format(amount);
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="p-6">
+          <div className="animate-pulse space-y-4">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-6 bg-muted rounded" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <DollarSign className="h-5 w-5" /> Unlocks per Chatter
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Chatter</TableHead>
+              <TableHead>Total</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {Object.entries(totals).map(([chatterId, amount]) => (
+              <TableRow key={chatterId}>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <User className="h-4 w-4 text-muted-foreground" />
+                    {names[chatterId] || chatterId}
+                  </div>
+                </TableCell>
+                <TableCell>{formatCurrency(amount)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+
+        {Object.keys(totals).length === 0 && (
+          <div className="text-center py-8 text-muted-foreground">
+            <DollarSign className="h-12 w-12 mx-auto mb-4 opacity-50" />
+            <p>No unlocks found for the selected period.</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add API route to fetch recent unlock data from F2F using provided cookies
- display unlock totals per chatter by matching unlock timestamps to shift schedules
- expose new "Unlocks" tab in manager dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d836507483279db7ade5f90650e2