### PR TITLE
Add daily unlocks tab for managers

### DIFF
--- a/components/daily-unlocks.tsx
+++ b/components/daily-unlocks.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Input } from "@/components/ui/input"
+import { User, Clock, DollarSign } from "lucide-react"
+import { api } from "@/lib/api"
+
+interface UnlockData {
+  chatterId: string | number
+  total: number
+}
+
+interface ShiftInfo {
+  chatterId: string
+  startTime: string
+  endTime: string
+}
+
+export function DailyUnlocks() {
+  const today = new Date().toISOString().split("T")[0]
+  const [date, setDate] = useState(today)
+  const [unlocks, setUnlocks] = useState<UnlockData[]>([])
+  const [userMap, setUserMap] = useState<Map<string, string>>(new Map())
+  const [shiftMap, setShiftMap] = useState<Map<string, ShiftInfo>>(new Map())
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true)
+      try {
+        const [unlockData, usersData, shiftsData] = await Promise.all([
+          api.getUnlocksPerChatter(date),
+          api.getUsers(),
+          api.getShifts(),
+        ])
+
+        const userMap = new Map(
+          (usersData || []).map((u: any) => [String(u.id), u.fullName || u.username || ""]),
+        )
+
+        const shiftMap = new Map<string, ShiftInfo>()
+        ;(shiftsData || []).forEach((s: any) => {
+          const shiftDate = (s.startTime || "").split("T")[0]
+          if (shiftDate === date) {
+            shiftMap.set(String(s.chatterId), {
+              chatterId: String(s.chatterId),
+              startTime: s.startTime,
+              endTime: s.endTime,
+            })
+          }
+        })
+
+        setUnlocks(unlockData || [])
+        setUserMap(userMap)
+        setShiftMap(shiftMap)
+      } catch (err) {
+        console.error("Error fetching daily unlocks:", err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [date])
+
+  const formatTime = (iso: string) => {
+    if (!iso) return "-"
+    return new Date(iso).toLocaleTimeString("nl-NL", {
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+  }
+
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat("nl-NL", { style: "currency", currency: "EUR" }).format(amount)
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Daily Unlocks</CardTitle>
+        <Input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="w-auto"
+        />
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="animate-pulse space-y-4">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-12 bg-muted rounded" />
+            ))}
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Chatter</TableHead>
+                <TableHead>Shift</TableHead>
+                <TableHead>Earnings</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {unlocks.map((u) => {
+                const chatterId = String(u.chatterId)
+                const shift = shiftMap.get(chatterId)
+                return (
+                  <TableRow key={chatterId}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <User className="h-4 w-4 text-muted-foreground" />
+                        {userMap.get(chatterId) || `Chatter ${chatterId}`}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {shift ? (
+                        <div className="flex items-center gap-2">
+                          <Clock className="h-4 w-4 text-muted-foreground" />
+                          {formatTime(shift.startTime)} - {formatTime(shift.endTime)}
+                        </div>
+                      ) : (
+                        <span className="text-muted-foreground">No shift</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1 font-semibold">
+                        <DollarSign className="h-4 w-4 text-green-600" />
+                        {formatCurrency(u.total)}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        )}
+        {!loading && unlocks.length === 0 && (
+          <div className="text-center py-8 text-muted-foreground">
+            <DollarSign className="h-12 w-12 mx-auto mb-4 opacity-50" />
+            <p>No unlocks for this date.</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/components/manager-dashboard.tsx
+++ b/components/manager-dashboard.tsx
@@ -19,7 +19,8 @@ import { CommissionCalculator } from "@/components/commission-calculator"
 import { Leaderboard } from "@/components/leaderboard"
 import { CreateChatterForm } from "@/components/create-chatter-form"
 import { WeeklyCalendar } from "@/components/weekly-calendar"
-import { Users, DollarSign, Calendar, TrendingUp, Award, Settings, UserPlus, RotateCcw, Shield } from "lucide-react"
+import { DailyUnlocks } from "@/components/daily-unlocks"
+import { Users, DollarSign, Calendar, TrendingUp, Award, Settings, UserPlus, RotateCcw, Shield, Unlock } from "lucide-react"
 import Image from "next/image"
 
 import { api } from "@/lib/api"
@@ -234,7 +235,7 @@ export function ManagerDashboard() {
 
           {/* Tabs */}
           <Tabs value={activeTab} onValueChange={setActiveTab} defaultValue="overview" className="space-y-6">
-            <TabsList className="grid w-full grid-cols-7">
+            <TabsList className="grid w-full grid-cols-8">
               <TabsTrigger value="overview" className="flex items-center gap-2">
                 <TrendingUp className="h-4 w-4" />
                 Overview
@@ -250,6 +251,10 @@ export function ManagerDashboard() {
               <TabsTrigger value="earnings" className="flex items-center gap-2">
                 <DollarSign className="h-4 w-4" />
                 Earnings
+              </TabsTrigger>
+              <TabsTrigger value="unlocks" className="flex items-center gap-2">
+                <Unlock className="h-4 w-4" />
+                Unlocks
               </TabsTrigger>
               <TabsTrigger value="shifts" className="flex items-center gap-2">
                 <Calendar className="h-4 w-4" />
@@ -361,6 +366,10 @@ export function ManagerDashboard() {
 
             <TabsContent value="earnings">
               <EarningsOverview />
+            </TabsContent>
+
+            <TabsContent value="unlocks">
+              <DailyUnlocks />
             </TabsContent>
 
             <TabsContent value="shifts">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -191,6 +191,12 @@ class ApiClient {
     return this.request(`/shifts/${id}`, { method: "DELETE" })
   }
 
+  /* ---------- Unlocks ---------- */
+  getUnlocksPerChatter(date?: string) {
+    const query = date ? `?date=${date}` : ""
+    return this.request(`/unlocks/per-chatter${query}`)
+  }
+
   /* ---------- Time Tracking ---------- */
   getActiveTimeEntry(chatterId: string) {
     return this.request(`/shifts/time-entry/active/${chatterId}`)


### PR DESCRIPTION
## Summary
- add API client method for `/unlocks/per-chatter`
- create `DailyUnlocks` component to display chatter earnings, shift time, and date filter
- integrate daily unlocks as a new tab in the manager dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint config setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e36570c08327bea823bd09c2541d