### PR TITLE
Use API for revenue data and allow overnight shifts

### DIFF
--- a/components/revenue-overview.tsx
+++ b/components/revenue-overview.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import {
   Card,
   CardContent,
@@ -11,13 +11,29 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
-import { useEmployeeEarnings } from "@/hooks/use-employee-earnings"
+import { api } from "@/lib/api"
 import { DollarSign, X } from "lucide-react"
 
 export function RevenueOverview() {
-  const { earnings, loading } = useEmployeeEarnings()
+  const [earnings, setEarnings] = useState<any[] | null>(null)
+  const [loading, setLoading] = useState(true)
   const [platformFee, setPlatformFee] = useState(20)
   const [adjustments, setAdjustments] = useState<number[]>([])
+
+  useEffect(() => {
+    const fetchEarnings = async () => {
+      try {
+        const data = await api.getRevenueEarnings()
+        setEarnings(data || [])
+      } catch (err) {
+        console.error("Failed to load revenue earnings:", err)
+        setEarnings([])
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchEarnings()
+  }, [])
 
   const total = (earnings || []).reduce(
       (sum: number, e: any) => sum + (e.amount || 0),

--- a/components/shift-manager.tsx
+++ b/components/shift-manager.tsx
@@ -166,7 +166,19 @@ export function ShiftManager() {
         e.preventDefault()
         try {
             const startDateTime = `${newShift.date}T${newShift.start_hour}:${newShift.start_minute}:00`
-            const endDateTime = `${newShift.date}T${newShift.end_hour}:${newShift.end_minute}:00`
+            let endDate = newShift.date
+
+            if (
+                parseInt(newShift.end_hour) < parseInt(newShift.start_hour) ||
+                (parseInt(newShift.end_hour) === parseInt(newShift.start_hour) &&
+                    parseInt(newShift.end_minute) <= parseInt(newShift.start_minute))
+            ) {
+                const nextDay = new Date(newShift.date)
+                nextDay.setDate(nextDay.getDate() + 1)
+                endDate = nextDay.toISOString().split("T")[0]
+            }
+
+            const endDateTime = `${endDate}T${newShift.end_hour}:${newShift.end_minute}:00`
 
             await api.createShift({
                 chatterId: newShift.chatter_id,


### PR DESCRIPTION
## Summary
- fetch revenue earnings via `api.getRevenueEarnings`
- allow scheduling shifts that extend past midnight

## Testing
- `pnpm lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bac52df0bc8327928e4d183ad92b76