### PR TITLE
Use API for revenue data and track online chatters

### DIFF
--- a/components/chatters-list.tsx
+++ b/components/chatters-list.tsx
@@ -81,10 +81,15 @@ export function ChattersList() {
 
   const fetchChatters = async () => {
     try {
-      const [chattersData, usersData] = await Promise.all([
+      const [chattersData, usersData, onlineChatters] = await Promise.all([
         api.getChatters(),
         api.getUsers(),
+        api.getOnlineChatters(),
       ])
+
+      const onlineIds = new Set(
+        (onlineChatters || []).map((c: any) => String(c.id)),
+      )
 
       const userMap = new Map(
           (usersData || []).map((u: any) => [
@@ -118,7 +123,7 @@ export function ChattersList() {
           full_name: user.full_name,
           email: chatter.email,
           created_at: chatter.createdAt,
-          isOnline: Math.random() > 0.6,
+          isOnline: onlineIds.has(String(chatter.id)),
           todayEarnings,
           weekEarnings,
           currency: chatter.currency || chatter.currency_symbol || "€",

--- a/components/manager-stats.tsx
+++ b/components/manager-stats.tsx
@@ -31,7 +31,10 @@ export function ManagerStats() {
 
     const calculateRealStats = async () => {
       try {
-        const chatters = await api.getChatters()
+        const [chatters, onlineChatters] = await Promise.all([
+          api.getChatters(),
+          api.getOnlineChatters(),
+        ])
 
         const today = new Date().toISOString().split("T")[0]
         const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split("T")[0]
@@ -49,11 +52,9 @@ export function ManagerStats() {
           .filter((e: any) => e.date.split("T")[0] >= oneMonthAgo)
           .reduce((sum: number, e: any) => sum + (e.amount || 0), 0)
 
-        const onlineCount = Math.floor((chatters?.length || 0) * 0.4)
-
         setStats({
           totalChatters: (chatters || []).length,
-          currentlyOnline: onlineCount,
+          currentlyOnline: (onlineChatters || []).length,
           totalEarningsToday: todayEarnings,
           totalEarningsWeek: weekEarnings,
           totalEarningsMonth: monthEarnings,

--- a/components/revenue-overview.tsx
+++ b/components/revenue-overview.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import {
   Card,
   CardContent,
@@ -11,13 +11,29 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
-import { useEmployeeEarnings } from "@/hooks/use-employee-earnings"
+import { api } from "@/lib/api"
 import { DollarSign, X } from "lucide-react"
 
 export function RevenueOverview() {
-  const { earnings, loading } = useEmployeeEarnings()
+  const [earnings, setEarnings] = useState<any[] | null>(null)
+  const [loading, setLoading] = useState(true)
   const [platformFee, setPlatformFee] = useState(20)
   const [adjustments, setAdjustments] = useState<number[]>([])
+
+  useEffect(() => {
+    const fetchEarnings = async () => {
+      try {
+        const data = await api.getRevenueEarnings()
+        setEarnings(data || [])
+      } catch (err) {
+        console.error("Failed to load revenue earnings:", err)
+        setEarnings([])
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchEarnings()
+  }, [])
 
   const total = (earnings || []).reduce(
       (sum: number, e: any) => sum + (e.amount || 0),

--- a/components/shift-manager.tsx
+++ b/components/shift-manager.tsx
@@ -166,7 +166,19 @@ export function ShiftManager() {
         e.preventDefault()
         try {
             const startDateTime = `${newShift.date}T${newShift.start_hour}:${newShift.start_minute}:00`
-            const endDateTime = `${newShift.date}T${newShift.end_hour}:${newShift.end_minute}:00`
+            let endDate = newShift.date
+
+            if (
+                parseInt(newShift.end_hour) < parseInt(newShift.start_hour) ||
+                (parseInt(newShift.end_hour) === parseInt(newShift.start_hour) &&
+                    parseInt(newShift.end_minute) <= parseInt(newShift.start_minute))
+            ) {
+                const nextDay = new Date(newShift.date)
+                nextDay.setDate(nextDay.getDate() + 1)
+                endDate = nextDay.toISOString().split("T")[0]
+            }
+
+            const endDateTime = `${endDate}T${newShift.end_hour}:${newShift.end_minute}:00`
 
             await api.createShift({
                 chatterId: newShift.chatter_id,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -111,6 +111,10 @@ class ApiClient {
     return this.request(`/chatters/${id}`)
   }
 
+  getOnlineChatters() {
+    return this.request("/chatters/online")
+  }
+
   createChatter(chatterData: any) {
     return this.request("/chatters", {
       method: "POST",


### PR DESCRIPTION
## Summary
- fetch revenue earnings via `api.getRevenueEarnings`
- allow scheduling shifts that extend past midnight
- retrieve online chatters for manager stats and chatter management

## Testing
- `pnpm lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bac52df0bc8327928e4d183ad92b76