### PR TITLE
fix: allow manual clock-in after shift start

### DIFF
--- a/components/clock-in-out.tsx
+++ b/components/clock-in-out.tsx
@@ -6,6 +6,16 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { Clock, Play, Square, Timer } from "lucide-react"
 import { api } from "@/lib/api"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 
 interface ClockInOutProps {
   userId: string,
@@ -23,25 +33,41 @@ export function ClockInOut({ userId, onChange }: ClockInOutProps) {
   const [loading, setLoading] = useState(true)
   const [actionLoading, setActionLoading] = useState(false)
   const [currentTime, setCurrentTime] = useState(new Date())
+  const [currentShift, setCurrentShift] = useState<any>(null)
+  const [showEarlyClockOut, setShowEarlyClockOut] = useState(false)
 
   useEffect(() => {
     if (!userId) return
 
     checkActiveEntry()
+    fetchCurrentShift()
 
     // Update current time every second
-    const timer = setInterval(() => {
+    const timeTimer = setInterval(() => {
       setCurrentTime(new Date())
     }, 1000)
 
-    return () => clearInterval(timer)
+    // Refresh shift and active entry info periodically
+    const syncTimer = setInterval(() => {
+      fetchCurrentShift()
+      checkActiveEntry()
+    }, 60000)
+
+    return () => {
+      clearInterval(timeTimer)
+      clearInterval(syncTimer)
+    }
   }, [userId])
 
   const checkActiveEntry = async () => {
     try {
       const entry = await api.getActiveTimeEntry(userId)
-      console.log("Active entry:", entry)
-      setActiveEntry(entry || null)
+      const now = new Date()
+      if (entry && entry.startTime && new Date(entry.startTime) <= now) {
+        setActiveEntry(entry)
+      } else {
+        setActiveEntry(null)
+      }
     } catch (error) {
       setActiveEntry(null)
     } finally {
@@ -49,9 +75,33 @@ export function ClockInOut({ userId, onChange }: ClockInOutProps) {
     }
   }
 
+  const fetchCurrentShift = async () => {
+    try {
+      const shifts = await api.getShifts()
+      const now = new Date()
+      const shift = (shifts || []).find(
+        (s: any) =>
+          String(s.chatterId) === String(userId) &&
+          new Date(s.startTime) <= now &&
+          new Date(s.endTime) >= now,
+      )
+      setCurrentShift(shift || null)
+      return shift || null
+    } catch (error) {
+      setCurrentShift(null)
+      return null
+    }
+  }
+
   const handleClockIn = async () => {
     setActionLoading(true)
     try {
+      const shift = await fetchCurrentShift()
+      const now = new Date()
+      if (!shift || new Date(shift.startTime) > now) {
+        alert("You can only clock in when your shift has started.")
+        return
+      }
       await api.clockIn(userId)
       await checkActiveEntry()
     } catch (error) {
@@ -61,7 +111,7 @@ export function ClockInOut({ userId, onChange }: ClockInOutProps) {
     }
   }
 
-  const handleClockOut = async () => {
+  const performClockOut = async () => {
     if (!activeEntry) return
 
     setActionLoading(true)
@@ -74,6 +124,19 @@ export function ClockInOut({ userId, onChange }: ClockInOutProps) {
     } finally {
       setActionLoading(false)
     }
+  }
+
+  const handleClockOut = () => {
+    if (!activeEntry) return
+    const now = new Date()
+    if (
+      currentShift &&
+      new Date(currentShift.endTime).getTime() - now.getTime() > 60 * 60 * 1000
+    ) {
+      setShowEarlyClockOut(true)
+      return
+    }
+    void performClockOut()
   }
 
   const formatTime = (date: Date) => {
@@ -188,7 +251,10 @@ export function ClockInOut({ userId, onChange }: ClockInOutProps) {
           ) : (
             <Button
               onClick={handleClockIn}
-              disabled={actionLoading}
+              disabled={
+                actionLoading ||
+                (currentShift && new Date(currentShift.startTime) > currentTime)
+              }
               className="w-full bg-green-600 hover:bg-green-700"
               size="lg"
             >
@@ -198,6 +264,27 @@ export function ClockInOut({ userId, onChange }: ClockInOutProps) {
           )}
         </div>
       </CardContent>
+      <AlertDialog open={showEarlyClockOut} onOpenChange={setShowEarlyClockOut}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clock out early?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You are attempting to clock out more than an hour before your shift ends. Are you sure you want to continue?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setShowEarlyClockOut(false)
+                void performClockOut()
+              }}
+            >
+              Clock Out
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   )
 }

--- a/components/weekly-calendar.tsx
+++ b/components/weekly-calendar.tsx
@@ -11,8 +11,8 @@ interface Shift {
   id: string
   chatter_id: string
   chatter_name: string
-  model_id: string[]
-  model_name: string[]
+  model_ids: string[]
+  model_names: string[]
   date: string
   start_time: string
   end_time: string
@@ -85,8 +85,10 @@ export function WeeklyCalendar({
         id: String(shift.id),
         chatter_id: String(shift.chatterId),
         chatter_name: chatterMap[String(shift.chatterId)] || "Unknown Chatter",
-        model_id: String(shift.modelIds),
-        model_name: modelMap[String(shift.modelIds)] || "No model",
+        model_ids: (shift.modelIds || []).map((id: any) => String(id)),
+        model_names: (shift.modelIds || []).map(
+            (id: any) => modelMap[String(id)] || "Unknown Model",
+        ),
         date: shift.startTime ? shift.startTime.split("T")[0] : shift.date,
         start_time: shift.startTime ? shift.startTime.substring(11, 16) : shift.startTime,
         end_time: shift.endTime ? shift.endTime.substring(11, 16) : shift.endTime,
@@ -201,9 +203,15 @@ export function WeeklyCalendar({
                         <Clock className="h-3 w-3" />
                         <span>{shift.start_time} - {shift.end_time}</span>
                       </div>
-                      <div className="flex items-center gap-1">
-                        <UserCircle className="h-3 w-3" />
-                        <span className="truncate">{shift.model_name}</span>
+                      <div className="flex items-start gap-1">
+                        <UserCircle className="h-3 w-3 mt-0.5" />
+                        <div className="flex flex-col">
+                          {shift.model_names.map((name: string, idx: number) => (
+                            <span key={idx} className="truncate">
+                              {name}
+                            </span>
+                          ))}
+                        </div>
                       </div>
                       {showChatterNames && (
                         <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- regularly sync active time entry and shift info so clock status updates after shift start
- let clock-in button be clickable even when a shift isn't detected yet

## Testing
- `npm run lint` (sh: 1: next: not found)
- `npm test` (npm error Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68bad65da75083278d178e14a9d8e5bd