### PR TITLE
Fetch chatter-specific revenues and update leaderboard

### DIFF
--- a/components/earnings-overview.tsx
+++ b/components/earnings-overview.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
-import { DollarSign, Calendar, User } from "lucide-react"
+import { DollarSign, Calendar, User, MessageSquare, Gift, Repeat, FileText } from "lucide-react"
 import { api } from "@/lib/api"
 import { useEmployeeEarnings } from "@/hooks/use-employee-earnings"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -18,6 +18,7 @@ interface EarningsData {
   date: string
   amount: number
   description: string | null
+  type: string
   chatterId: string | null
   chatter: {
     full_name: string
@@ -84,6 +85,7 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
             date: earning.date,
             amount: earning.amount,
             description: earning.description,
+            type: earning.type,
             chatterId,
             chatter: earning.chatterId ? { full_name } : null,
           }
@@ -180,6 +182,7 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
           <TableHeader>
             <TableRow>
               <TableHead>Date</TableHead>
+              <TableHead>Type</TableHead>
               <TableHead>Chatter</TableHead>
               <TableHead>Amount</TableHead>
               <TableHead>Description</TableHead>
@@ -195,28 +198,43 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
                   </div>
                 </TableCell>
                 <TableCell>
-                  {limit ? (
-                    <div className="flex items-center gap-2">
-                      <User className="h-4 w-4 text-muted-foreground" />
-                      {earning.chatter?.full_name ?? "Unknown chatter"}
-                    </div>
-                  ) : (
-                    <Select
-                      value={earning.chatterId ?? "unknown"}
-                      onValueChange={(value) => handleChatterChange(earning.id, value)}
-                    >
-                      <SelectTrigger className="w-[200px]">
+                  {(() => {
+                    const iconMap: Record<string, JSX.Element> = {
+                      paypermessage: <MessageSquare className="h-4 w-4 text-muted-foreground" />,
+                      tip: <Gift className="h-4 w-4 text-muted-foreground" />,
+                      subscriptionperiod: <Repeat className="h-4 w-4 text-muted-foreground" />,
+                      payperpost: <FileText className="h-4 w-4 text-muted-foreground" />,
+                    }
+                    return iconMap[earning.type] || null
+                  })()}
+                </TableCell>
+                <TableCell>
+                  {['paypermessage','tip'].includes(earning.type) ? (
+                    limit ? (
+                      <div className="flex items-center gap-2">
                         <User className="h-4 w-4 text-muted-foreground" />
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {chatters.map((chatter) => (
-                          <SelectItem key={chatter.id} value={chatter.id}>
-                            {chatter.full_name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                        {earning.chatter?.full_name ?? "Unknown chatter"}
+                      </div>
+                    ) : (
+                      <Select
+                        value={earning.chatterId ?? "unknown"}
+                        onValueChange={(value) => handleChatterChange(earning.id, value)}
+                      >
+                        <SelectTrigger className="w-[200px]">
+                          <User className="h-4 w-4 text-muted-foreground" />
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {chatters.map((chatter) => (
+                            <SelectItem key={chatter.id} value={chatter.id}>
+                              {chatter.full_name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
                   )}
                 </TableCell>
                 <TableCell>

--- a/components/employee-dashboard.tsx
+++ b/components/employee-dashboard.tsx
@@ -188,7 +188,7 @@ export function EmployeeDashboard() {
 
         {/* Main Content */}
         <main className="container mx-auto px-4 py-6">
-          <EmployeeEarningsProvider>
+          <EmployeeEarningsProvider userId={user.id}>
             {/* Stats Overview */}
             <div className="mb-8">
               <EmployeeStats userId={user.id} refreshTrigger={refreshStats} />

--- a/components/employee-earnings-history.tsx
+++ b/components/employee-earnings-history.tsx
@@ -28,12 +28,11 @@ export function EmployeeEarningsHistory({ userId, limit }: EmployeeEarningsHisto
     const fetchEarnings = async () => {
       try {
         const [earningsData, chatter] = await Promise.all([
-          api.getEmployeeEarnings(),
+          api.getEmployeeEarningsByChatter(userId),
           api.getChatter(userId).catch(() => null),
         ])
 
         const userEarnings = (earningsData || [])
-          .filter((e: any) => String(e.chatterId) === String(userId))
           .map((e: any) => ({
             id: String(e.id),
             date: e.date,

--- a/hooks/use-employee-earnings.tsx
+++ b/hooks/use-employee-earnings.tsx
@@ -11,14 +11,18 @@ interface EmployeeEarningsContextValue {
 
 const EmployeeEarningsContext = createContext<EmployeeEarningsContextValue | undefined>(undefined)
 
-export function EmployeeEarningsProvider({ children }: { children: ReactNode }) {
+interface ProviderProps { children: ReactNode; userId?: string }
+
+export function EmployeeEarningsProvider({ children, userId }: ProviderProps) {
   const [earnings, setEarnings] = useState<any[] | null>(null)
   const [loading, setLoading] = useState(true)
 
   const refresh = async () => {
     try {
       setLoading(true)
-      const data = await api.getEmployeeEarnings()
+      const data = userId
+        ? await api.getEmployeeEarningsByChatter(userId)
+        : await api.getEmployeeEarnings()
       setEarnings(data || [])
     } catch (err) {
       console.error("Failed to load employee earnings:", err)
@@ -30,7 +34,7 @@ export function EmployeeEarningsProvider({ children }: { children: ReactNode }) 
 
   useEffect(() => {
     refresh()
-  }, [])
+  }, [userId])
 
   return (
     <EmployeeEarningsContext.Provider value={{ earnings, loading, refresh }}>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -147,6 +147,14 @@ class ApiClient {
     return this.request("/employee-earnings")
   }
 
+  getEmployeeEarningsByChatter(id: string) {
+    return this.request(`/employee-earnings/chatter/${id}`)
+  }
+
+  getEmployeeEarningsLeaderboard() {
+    return this.request("/employee-earnings/leaderboard")
+  }
+
   getEmployeeEarning(id: string) {
     return this.request(`/employee-earnings/${id}`)
   }


### PR DESCRIPTION
## Summary
- Retrieve earnings via `/employee-earnings/chatter/:id` and expose leaderboard endpoint
- Use per-chatter earnings context in employee dashboard and stats
- Show earning type icons and hide chatter column for non-message/tip entries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf43ece048327a60bb09de941f5ec