### PR TITLE
Fix shift date parsing in WeeklyCalendar

### DIFF
--- a/components/weekly-calendar.tsx
+++ b/components/weekly-calendar.tsx
@@ -81,19 +81,31 @@ export function WeeklyCalendar({
         modelMap[String(model.id)] = model.displayName || "Unknown Model"
       })
 
-      const formattedShifts = (shiftsData || []).map((shift: any) => ({
-        id: String(shift.id),
-        chatter_id: String(shift.chatterId),
-        chatter_name: chatterMap[String(shift.chatterId)] || "Unknown Chatter",
-        model_ids: (shift.modelIds || []).map((id: any) => String(id)),
-        model_names: (shift.modelIds || []).map(
+      const formattedShifts = (shiftsData || []).map((shift: any) => {
+        const startDate = shift.startTime
+          ? String(shift.startTime).slice(0, 10)
+          : String(shift.date)
+        const startTime = shift.startTime
+          ? String(shift.startTime).slice(11, 16)
+          : ""
+        const endTime = shift.endTime
+          ? String(shift.endTime).slice(11, 16)
+          : ""
+
+        return {
+          id: String(shift.id),
+          chatter_id: String(shift.chatterId),
+          chatter_name: chatterMap[String(shift.chatterId)] || "Unknown Chatter",
+          model_ids: (shift.modelIds || []).map((id: any) => String(id)),
+          model_names: (shift.modelIds || []).map(
             (id: any) => modelMap[String(id)] || "Unknown Model",
-        ),
-        date: shift.startTime ? shift.startTime : shift.date,
-        start_time: shift.startTime,
-        end_time: shift.endTime,
-        status: shift.status,
-      }))
+          ),
+          date: startDate,
+          start_time: startTime,
+          end_time: endTime,
+          status: shift.status,
+        }
+      })
 
       console.log("Formatted shifts:", formattedShifts)
 


### PR DESCRIPTION
## Summary
- Parse shift start and end times to extract date-only value for weekly filtering
- Format shift times to only show hours and minutes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: aborted after warnings about invalid config and telemetry prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bff7023aa08327b2c4695bf2e9effa