### PR TITLE
Add earnings sync button

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -183,6 +183,17 @@ class ApiClient {
     return this.request(`/employee-earnings/${id}`, { method: "DELETE" })
   }
 
+  syncEarnings(from: string | Date, to: string | Date) {
+    const payload = {
+      from: typeof from === "string" ? from : from.toISOString(),
+      to: typeof to === "string" ? to : to.toISOString(),
+    }
+    return this.request(`/earnings/sync`, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    })
+  }
+
   /* ---------- Revenue ---------- */
   getRevenueEarnings() {
     return this.request("/revenue/earnings")


### PR DESCRIPTION
## Summary
- add API client helper to sync earnings
- add Sync Earnings button to earnings overview to invoke endpoint
- prompt user with modal to choose sync start and end dates

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c000348448832785a0f821a6388e0e