### PR TITLE
feat: show daily revenue chart

### DIFF
--- a/components/revenue-overview.tsx
+++ b/components/revenue-overview.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
+
 import {
   Card,
   CardContent,
@@ -8,84 +9,159 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
-import { api } from "@/lib/api"
 import { DollarSign, X } from "lucide-react"
+import { Bar, BarChart, XAxis, YAxis } from "recharts"
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
+import { api } from "@/lib/api"
+
+interface RevenueEntry {
+  id: string
+  date: string
+  amount: number
+  modelCommissionRate: number
+  chatterCommissionRate: number
+}
+
+interface DailyData {
+  day: number
+  revenue: number
+  fullDate: string
+  entries: RevenueEntry[]
+}
 
 export function RevenueOverview() {
-  const [earnings, setEarnings] = useState<any[] | null>(null)
+  const [entries, setEntries] = useState<RevenueEntry[]>([])
   const [loading, setLoading] = useState(true)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [platformFee, setPlatformFee] = useState(20)
   const [adjustments, setAdjustments] = useState<number[]>([])
 
   useEffect(() => {
-    const fetchEarnings = async () => {
+    const fetchRevenue = async () => {
       try {
         const data = await api.getRevenueEarnings()
-        setEarnings(data || [])
+        const formatted = (data || []).map((e: any) => ({
+          id: String(e.id),
+          date: e.date || e.created_at,
+          amount: e.amount || 0,
+          modelCommissionRate:
+            e.modelCommissionRate ?? e.model_commission_rate ?? 0,
+          chatterCommissionRate:
+            e.chatterCommissionRate ?? e.chatter_commission_rate ?? 0,
+        }))
+        setEntries(formatted)
       } catch (err) {
         console.error("Failed to load revenue earnings:", err)
-        setEarnings([])
       } finally {
         setLoading(false)
       }
     }
-    fetchEarnings()
+    fetchRevenue()
   }, [])
 
-  const total = (earnings || []).reduce(
-      (sum: number, e: any) => sum + (e.amount || 0),
-      0
-  )
-  const platformFeeAmount = total * (platformFee / 100)
-  const afterPlatform = total - platformFeeAmount
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth()
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
 
-  let modelCommission = 0
-  let chatterCommission = 0
-  const monthlyMap = new Map<string, number>()
-  ;(earnings || []).forEach((e: any) => {
-    const amount = e.amount || 0
-    const net = amount * (1 - platformFee / 100)
-    const mRate =
-        e.modelCommissionRate ?? e.model_commission_rate ?? 0
-    const cRate =
-        e.chatterCommissionRate ?? e.chatter_commission_rate ?? 0
-    const mComm = net * (mRate / 100)
-    const cComm = net * (cRate / 100)
-    modelCommission += mComm
-    chatterCommission += cComm
-    const company = net - mComm - cComm
-    const date = new Date(e.date || e.created_at)
-    const key = `${date.getFullYear()}-${String(
-        date.getMonth() + 1
-    ).padStart(2, "0")}`
-    monthlyMap.set(key, (monthlyMap.get(key) || 0) + company)
-  })
-
-  const monthlyEntries = Array.from(monthlyMap.entries()).sort(
-      (a, b) => a[0].localeCompare(b[0])
+  const monthlyEntries = useMemo(
+    () =>
+      entries.filter((e) => {
+        const d = new Date(e.date)
+        return d.getFullYear() === year && d.getMonth() === month
+      }),
+    [entries, year, month],
   )
 
-  const companyRevenue = afterPlatform - modelCommission - chatterCommission
-  const adjustmentsTotal = adjustments.reduce((sum, val) => sum + (val || 0), 0)
+  const dailyData: DailyData[] = useMemo(() => {
+    return Array.from({ length: daysInMonth }, (_, i) => {
+      const day = i + 1
+      const fullDate = new Date(year, month, day)
+        .toISOString()
+        .split("T")[0]
+      const dayEntries = monthlyEntries.filter((e) =>
+        e.date.startsWith(fullDate),
+      )
+      const revenue = dayEntries.reduce((sum, e) => {
+        const net = e.amount * (1 - platformFee / 100)
+        const mComm = net * (e.modelCommissionRate / 100)
+        const cComm = net * (e.chatterCommissionRate / 100)
+        return sum + (net - mComm - cComm)
+      }, 0)
+      return { day, revenue, fullDate, entries: dayEntries }
+    })
+  }, [monthlyEntries, daysInMonth, year, month, platformFee])
+
+  const monthTotals = useMemo(() => {
+    return monthlyEntries.reduce(
+      (acc, e) => {
+        const amount = e.amount
+        const net = amount * (1 - platformFee / 100)
+        const mComm = net * (e.modelCommissionRate / 100)
+        const cComm = net * (e.chatterCommissionRate / 100)
+        acc.total += amount
+        acc.platformFee += amount - net
+        acc.afterPlatform += net
+        acc.modelCommission += mComm
+        acc.chatterCommission += cComm
+        return acc
+      },
+      {
+        total: 0,
+        platformFee: 0,
+        afterPlatform: 0,
+        modelCommission: 0,
+        chatterCommission: 0,
+      },
+    )
+  }, [monthlyEntries, platformFee])
+
+  const companyRevenue =
+    monthTotals.afterPlatform -
+    monthTotals.modelCommission -
+    monthTotals.chatterCommission
+  const adjustmentsTotal = adjustments.reduce(
+    (sum, val) => sum + (val || 0),
+    0,
+  )
   const finalRevenue = companyRevenue + adjustmentsTotal
 
-  const formatCurrency = (amount: number) =>
-      new Intl.NumberFormat("nl-NL", {
-        style: "currency",
-        currency: "EUR",
-      }).format(amount)
+  const selectedEntries = selectedDate
+    ? dailyData.find((d) => d.fullDate === selectedDate)?.entries || []
+    : []
 
-  const formatMonth = (month: string) => {
-    const [year, m] = month.split("-")
-    const date = new Date(Number(year), Number(m) - 1)
-    return date.toLocaleDateString("nl-NL", {
+  const selectedTotal = selectedDate
+    ? dailyData.find((d) => d.fullDate === selectedDate)?.revenue || 0
+    : 0
+
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat("nl-NL", {
+      style: "currency",
+      currency: "EUR",
+    }).format(amount)
+
+  const formatFullDate = (date: string) =>
+    new Date(date).toLocaleDateString("nl-NL", {
+      weekday: "long",
       month: "long",
-      year: "numeric",
+      day: "numeric",
     })
-  }
 
   const addAdjustment = () => setAdjustments([...adjustments, 0])
   const updateAdjustment = (index: number, value: number) => {
@@ -99,109 +175,195 @@ export function RevenueOverview() {
 
   if (loading) {
     return (
-        <Card>
-          <CardContent className="p-6">
-            <div className="animate-pulse space-y-4">
-              <div className="h-12 bg-muted rounded" />
-              <div className="h-12 bg-muted rounded" />
-              <div className="h-12 bg-muted rounded" />
-            </div>
-          </CardContent>
-        </Card>
+      <Card>
+        <CardContent className="p-6">
+          <div className="animate-pulse space-y-4">
+            <div className="h-12 bg-muted rounded" />
+            <div className="h-12 bg-muted rounded" />
+            <div className="h-12 bg-muted rounded" />
+          </div>
+        </CardContent>
+      </Card>
     )
   }
 
+  const chartConfig = {
+    revenue: {
+      label: "Revenue",
+      color: "hsl(var(--chart-1))",
+    },
+  }
+
   return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <DollarSign className="h-5 w-5" />
-            Revenue Overview
-          </CardTitle>
-          <CardDescription>
-            Total revenue after platform, model and chatter commissions.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          {monthlyEntries.length > 0 && (
-              <div className="overflow-x-auto">
-                <div className="flex gap-4 pb-4">
-                  {monthlyEntries.map(([month, amount]) => (
-                      <div key={month} className="min-w-[100px] text-center">
-                        <div className="font-medium">{formatMonth(month)}</div>
-                        <div className="text-sm">{formatCurrency(amount)}</div>
-                      </div>
-                  ))}
-                </div>
-              </div>
-          )}
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="platform-fee">Platform fee (%)</Label>
-              <Input
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <DollarSign className="h-5 w-5" />
+          Revenue Overview
+        </CardTitle>
+        <CardDescription>
+          Company revenue for {" "}
+          {now.toLocaleDateString("nl-NL", { month: "long", year: "numeric" })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ChartContainer config={chartConfig} className="h-64">
+          <BarChart data={dailyData}>
+            <XAxis dataKey="day" tickLine={false} axisLine={false} />
+            <YAxis tickLine={false} axisLine={false} width={40} />
+            <Bar
+              dataKey="revenue"
+              fill="var(--color-revenue)"
+              onClick={(data: any) =>
+                data?.payload?.fullDate && setSelectedDate(data.payload.fullDate)
+              }
+            />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  formatter={(value) => formatCurrency(value as number)}
+                />
+              }
+            />
+          </BarChart>
+        </ChartContainer>
+
+        {selectedDate ? (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="font-medium">{formatFullDate(selectedDate)}</h3>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSelectedDate(null)}
+              >
+                Back
+              </Button>
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Gross</TableHead>
+                  <TableHead>Model %</TableHead>
+                  <TableHead>Chatter %</TableHead>
+                  <TableHead className="text-right">Company</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {selectedEntries.map((e) => {
+                  const net = e.amount * (1 - platformFee / 100)
+                  const mComm = net * (e.modelCommissionRate / 100)
+                  const cComm = net * (e.chatterCommissionRate / 100)
+                  const company = net - mComm - cComm
+                  return (
+                    <TableRow key={e.id}>
+                      <TableCell>{formatCurrency(e.amount)}</TableCell>
+                      <TableCell>{e.modelCommissionRate}%</TableCell>
+                      <TableCell>{e.chatterCommissionRate}%</TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(company)}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+                {selectedEntries.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center">
+                      No entries
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+            <div className="text-right font-medium">
+              Total: {formatCurrency(selectedTotal)}
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="platform-fee">Platform fee (%)</Label>
+                <Input
                   id="platform-fee"
                   type="number"
                   value={platformFee}
                   onChange={(e) => setPlatformFee(Number(e.target.value) || 0)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>Manual adjustments (negative = cost)</Label>
-              {adjustments.map((adj, idx) => (
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Manual adjustments (negative = cost)</Label>
+                {adjustments.map((adj, idx) => (
                   <div key={idx} className="flex items-center gap-2">
                     <Input
-                        type="number"
-                        value={adj}
-                        onChange={(e) => updateAdjustment(idx, Number(e.target.value) || 0)}
+                      type="number"
+                      value={adj}
+                      onChange={(e) =>
+                        updateAdjustment(idx, Number(e.target.value) || 0)
+                      }
                     />
-                    <Button variant="outline" size="icon" onClick={() => removeAdjustment(idx)}>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => removeAdjustment(idx)}
+                    >
                       <X className="h-4 w-4" />
                     </Button>
                   </div>
-              ))}
-              <Button variant="outline" onClick={addAdjustment} className="w-full">
-                Add adjustment
-              </Button>
+                ))}
+                <Button
+                  variant="outline"
+                  onClick={addAdjustment}
+                  className="w-full"
+                >
+                  Add adjustment
+                </Button>
+              </div>
             </div>
-          </div>
 
-          <div className="space-y-2">
-            <div className="flex justify-between">
-              <span>Total earnings</span>
-              <span>{formatCurrency(total)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>Platform fee ({platformFee}%)</span>
-              <span>-{formatCurrency(platformFeeAmount)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>After platform</span>
-              <span>{formatCurrency(afterPlatform)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>Model commissions</span>
-              <span>-{formatCurrency(modelCommission)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>Chatter commissions</span>
-              <span>-{formatCurrency(chatterCommission)}</span>
-            </div>
-            <div className="flex justify-between font-medium">
-              <span>Company revenue</span>
-              <span>{formatCurrency(companyRevenue)}</span>
-            </div>
-            {adjustmentsTotal !== 0 && (
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span>Total earnings</span>
+                <span>{formatCurrency(monthTotals.total)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Platform fee ({platformFee}%)</span>
+                <span>-{formatCurrency(monthTotals.platformFee)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>After platform</span>
+                <span>{formatCurrency(monthTotals.afterPlatform)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Model commissions</span>
+                <span>-{formatCurrency(monthTotals.modelCommission)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Chatter commissions</span>
+                <span>-{formatCurrency(monthTotals.chatterCommission)}</span>
+              </div>
+              <div className="flex justify-between font-medium">
+                <span>Company revenue</span>
+                <span>{formatCurrency(companyRevenue)}</span>
+              </div>
+              {adjustmentsTotal !== 0 && (
                 <div className="flex justify-between">
                   <span>Adjustments</span>
-                  <span>{adjustmentsTotal >= 0 ? "+" : ""}{formatCurrency(adjustmentsTotal)}</span>
+                  <span>
+                    {adjustmentsTotal >= 0 ? "+" : ""}
+                    {formatCurrency(adjustmentsTotal)}
+                  </span>
                 </div>
-            )}
-            <div className="flex justify-between font-bold">
-              <span>Final revenue</span>
-              <span>{formatCurrency(finalRevenue)}</span>
+              )}
+              <div className="flex justify-between font-bold">
+                <span>Final revenue</span>
+                <span>{formatCurrency(finalRevenue)}</span>
+              </div>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        )}
+      </CardContent>
+    </Card>
   )
 }
+


### PR DESCRIPTION
## Summary
- restore original earnings overview table
- display daily revenue in a monthly bar chart with selectable day details

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c1249460688327b18c9cf88ee5000f