### PR TITLE
feat: show daily revenue chart and paginated earnings list

### DIFF
--- a/components/earnings-overview.tsx
+++ b/components/earnings-overview.tsx
@@ -1,9 +1,23 @@
 "use client"
 
-import { useEffect, useState, useRef, useCallback } from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { useEffect, useMemo, useState } from "react"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 import {
   Dialog,
   DialogContent,
@@ -15,10 +29,40 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { DollarSign, Calendar, User, MessageSquare, Gift, Repeat, FileText } from "lucide-react"
+import {
+  DollarSign,
+  Calendar,
+  User,
+  MessageSquare,
+  Gift,
+  Repeat,
+  FileText,
+  X,
+} from "lucide-react"
+import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts"
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
 import { api } from "@/lib/api"
 import { useEmployeeEarnings } from "@/hooks/use-employee-earnings"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination"
 
 interface EarningsOverviewProps {
   limit?: number
@@ -37,23 +81,18 @@ interface EarningsData {
 }
 
 export function EarningsOverview({ limit }: EarningsOverviewProps) {
-  const [earnings, setEarnings] = useState<EarningsData[]>([])
-  const [loading, setLoading] = useState(true)
-  const [loadingMore, setLoadingMore] = useState(false)
+  const { earnings: allEarnings, loading, refresh } = useEmployeeEarnings()
   const [chatters, setChatters] = useState<{ id: string; full_name: string }[]>([])
+  const [chatterMap, setChatterMap] = useState<Map<string, string>>(new Map())
   const [chatterFilter, setChatterFilter] = useState("all")
   const [typeFilter, setTypeFilter] = useState("all")
-  const [hasMore, setHasMore] = useState(true)
-  const offsetRef = useRef(0)
-  const hasMoreRef = useRef(true)
-  const loadingMoreRef = useRef(false)
-  const [chatterMap, setChatterMap] = useState<Map<string, string>>(new Map())
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [hoveredBar, setHoveredBar] = useState<number | null>(null)
   const [syncOpen, setSyncOpen] = useState(false)
   const [syncFrom, setSyncFrom] = useState("")
   const [syncTo, setSyncTo] = useState("")
-
-  const { refresh } = useEmployeeEarnings()
+  const [page, setPage] = useState(1)
+  const pageSize = 20
 
   useEffect(() => {
     const loadChatters = async () => {
@@ -86,85 +125,77 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
     loadChatters()
   }, [])
 
-  const loadEarnings = useCallback(
-    async (reset = false) => {
-      if (reset) {
-        setLoading(true)
-        offsetRef.current = 0
-        setHasMore(true)
-      } else {
-        setLoadingMore(true)
-      }
-      try {
-        const params: any = {
-          limit: limit ?? 20,
-          offset: offsetRef.current,
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth()
+
+  const monthlyEarnings = useMemo(() => {
+    return (allEarnings || []).filter((e: any) => {
+      const d = new Date(e.date)
+      return d.getFullYear() === year && d.getMonth() === month
+    })
+  }, [allEarnings, year, month])
+
+  const baseEarnings = limit ? (allEarnings || []) : monthlyEarnings
+
+  const chartData = useMemo(() => {
+    const daysInMonth = new Date(year, month + 1, 0).getDate()
+    return Array.from({ length: daysInMonth }, (_, i) => {
+      const day = i + 1
+      const fullDate = new Date(year, month, day).toISOString().split("T")[0]
+      const dayEntries = monthlyEarnings.filter((e: any) =>
+        e.date.startsWith(fullDate),
+      )
+      const total = dayEntries.reduce(
+        (sum: number, e: any) => sum + Number(e.amount || 0),
+        0,
+      )
+      return { day, total, fullDate }
+    })
+  }, [monthlyEarnings, year, month])
+
+  const filteredEarnings = useMemo(() => {
+    let data: EarningsData[] = baseEarnings
+    if (selectedDate) {
+      data = data.filter((e: any) => e.date.startsWith(selectedDate))
+    }
+    if (chatterFilter !== "all") {
+      data = data.filter((e: any) => String(e.chatterId) === chatterFilter)
+    }
+    if (typeFilter !== "all") {
+      data = data.filter((e: any) => e.type === typeFilter)
+    }
+    return data
+      .map((earning: any) => {
+        const chatterId = earning.chatterId ? String(earning.chatterId) : null
+        const full_name = earning.chatterId
+          ? chatterMap.get(String(earning.chatterId)) || "Wolf"
+          : "Wolf"
+        return {
+          id: String(earning.id),
+          date: earning.date,
+          amount: Number(earning.amount),
+          description: earning.description,
+          type: earning.type,
+          chatterId,
+          chatter: earning.chatterId ? { full_name } : null,
         }
-        if (chatterFilter !== "all") params.chatterId = chatterFilter
-        if (typeFilter !== "all") params.type = typeFilter
-        const data = await api.getEmployeeEarnings(params)
-        const formatted = (data || [])
-          .map((earning: any) => {
-            const chatterId = earning.chatterId
-              ? String(earning.chatterId)
-              : null
-            const full_name = earning.chatterId
-              ? chatterMap.get(String(earning.chatterId)) || "Wolf"
-              : "Wolf"
-            return {
-              id: String(earning.id),
-              date: earning.date,
-              amount: earning.amount,
-              description: earning.description,
-              type: earning.type,
-              chatterId,
-              chatter: earning.chatterId ? { full_name } : null,
-            }
-          })
-          .sort(
-            (a: any, b: any) =>
-              new Date(b.date).getTime() - new Date(a.date).getTime(),
-          )
-        setEarnings((prev) => (reset ? formatted : [...prev, ...formatted]))
-        offsetRef.current = reset
-          ? formatted.length
-          : offsetRef.current + formatted.length
-        if (!data || data.length < (limit ?? 20)) setHasMore(false)
-      } catch (error) {
-        console.error("Error fetching earnings:", error)
-      } finally {
-        if (reset) setLoading(false)
-        setLoadingMore(false)
-      }
-    },
-    [limit, chatterFilter, typeFilter, chatterMap],
+      })
+      .sort(
+        (a: any, b: any) =>
+          new Date(b.date).getTime() - new Date(a.date).getTime(),
+      )
+  }, [monthlyEarnings, selectedDate, chatterFilter, typeFilter, chatterMap])
+
+  const pageCount = Math.ceil(filteredEarnings.length / pageSize)
+  const paginated = filteredEarnings.slice(
+    (page - 1) * pageSize,
+    page * pageSize,
   )
 
   useEffect(() => {
-    hasMoreRef.current = hasMore
-  }, [hasMore])
-
-  useEffect(() => {
-    loadingMoreRef.current = loadingMore
-  }, [loadingMore])
-
-  useEffect(() => {
-    if (chatterMap.size === 0) return
-    loadEarnings(true)
-  }, [chatterFilter, typeFilter, chatterMap, loadEarnings])
-
-  useEffect(() => {
-    if (limit || loading || !hasMore) return
-    const node = loadMoreRef.current
-    if (!node) return
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting && hasMoreRef.current && !loadingMoreRef.current) {
-        loadEarnings()
-      }
-    })
-    observer.observe(node)
-    return () => observer.disconnect()
-  }, [limit, loadEarnings, loading, hasMore])
+    setPage(1)
+  }, [selectedDate, chatterFilter, typeFilter])
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat("nl-NL", {
@@ -186,21 +217,6 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
       await api.updateEmployeeEarning(earningId, {
         chatterId: chatterId === "unknown" ? null : chatterId,
       })
-      const selected = chatters.find((c) => c.id === chatterId)
-      setEarnings((prev) =>
-        prev.map((e) =>
-          e.id === earningId
-            ? {
-                ...e,
-                chatterId: chatterId === "unknown" ? null : chatterId,
-                chatter:
-                  chatterId === "unknown"
-                    ? null
-                    : { full_name: selected?.full_name || "" },
-              }
-            : e,
-        ),
-      )
       await refresh()
     } catch (error) {
       console.error("Error updating earning:", error)
@@ -211,14 +227,13 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
     try {
       if (!syncFrom || !syncTo) return
       await api.syncEarnings(new Date(syncFrom), new Date(syncTo))
-      await loadEarnings(true)
       await refresh()
     } catch (error) {
       console.error("Error syncing earnings:", error)
     }
   }
 
-  if (loading) {
+  if (loading || !allEarnings) {
     return (
       <Card>
         <CardContent className="p-6">
@@ -232,6 +247,89 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
     )
   }
 
+  if (limit) {
+    const limited = filteredEarnings.slice(0, limit)
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <DollarSign className="h-5 w-5" />
+            Earnings Overview
+          </CardTitle>
+          <CardDescription>
+            Latest {limit} earnings entries
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Chatter</TableHead>
+                <TableHead>Amount</TableHead>
+                <TableHead>Description</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {limited.map((earning) => (
+                <TableRow key={earning.id}>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <Calendar className="h-4 w-4 text-muted-foreground" />
+                      {formatDate(earning.date)}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    {(() => {
+                      const iconMap: Record<string, JSX.Element> = {
+                        paypermessage: (
+                          <MessageSquare className="h-4 w-4 text-muted-foreground" />
+                        ),
+                        tip: <Gift className="h-4 w-4 text-muted-foreground" />,
+                        subscriptionperiod: (
+                          <Repeat className="h-4 w-4 text-muted-foreground" />
+                        ),
+                        payperpost: (
+                          <FileText className="h-4 w-4 text-muted-foreground" />
+                        ),
+                      }
+                      return iconMap[earning.type] || null
+                    })()}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <User className="h-4 w-4 text-muted-foreground" />
+                      {earning.chatter?.full_name ?? "Wolf"}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1 font-semibold">
+                      <DollarSign className="h-4 w-4 text-green-600" />
+                      {formatCurrency(earning.amount)}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <span className="text-muted-foreground">
+                      {earning.description || "No description"}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const chartConfig = {
+    total: {
+      label: "Earnings",
+      color: "#6CE8F2",
+    },
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -239,85 +337,143 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
           <DollarSign className="h-5 w-5" />
           Earnings Overview
         </CardTitle>
-        <CardDescription>{limit ? `Latest ${limit} earnings entries` : "All earnings entries"}</CardDescription>
-        {!limit && (
-          <div className="flex flex-col gap-4 mt-4 md:flex-row md:items-center">
-            <Select value={chatterFilter} onValueChange={setChatterFilter}>
-              <SelectTrigger className="w-[200px]">
-                <User className="h-4 w-4 text-muted-foreground" />
-                <SelectValue placeholder="All chatters" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All chatters</SelectItem>
-                {chatters.map((chatter) => (
-                  <SelectItem key={chatter.id} value={chatter.id}>
-                    {chatter.full_name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select value={typeFilter} onValueChange={setTypeFilter}>
-              <SelectTrigger className="w-[200px]">
-                <SelectValue placeholder="All types" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All types</SelectItem>
-                <SelectItem value="paypermessage">Pay per message</SelectItem>
-                <SelectItem value="tip">Tip</SelectItem>
-                <SelectItem value="subscriptionperiod">Subscription period</SelectItem>
-                <SelectItem value="payperpost">Pay per post</SelectItem>
-              </SelectContent>
-            </Select>
-            <Dialog open={syncOpen} onOpenChange={setSyncOpen}>
-              <DialogTrigger asChild>
-                <Button className="md:ml-auto">Sync Earnings</Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Sync Earnings</DialogTitle>
-                  <DialogDescription>
-                    Select the start and end date times.
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-4">
-                  <div className="flex flex-col gap-2">
-                    <Label htmlFor="sync-from">From</Label>
-                    <Input
-                      id="sync-from"
-                      type="datetime-local"
-                      value={syncFrom}
-                      onChange={(e) => setSyncFrom(e.target.value)}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <Label htmlFor="sync-to">To</Label>
-                    <Input
-                      id="sync-to"
-                      type="datetime-local"
-                      value={syncTo}
-                      onChange={(e) => setSyncTo(e.target.value)}
-                    />
-                  </div>
-                </div>
-                <DialogFooter>
-                  <Button variant="secondary" onClick={() => setSyncOpen(false)}>
-                    Cancel
-                  </Button>
-                  <Button
-                    onClick={async () => {
-                      await handleSync()
-                      setSyncOpen(false)
-                    }}
-                  >
-                    Sync
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
+        <CardDescription>
+          {now.toLocaleDateString("nl-NL", { month: "long", year: "numeric" })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ChartContainer config={chartConfig} className="h-64 w-full">
+          <BarChart data={chartData}>
+            <defs>
+              <linearGradient id="earningsGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#6CE8F2" />
+                <stop offset="100%" stopColor="#FFA6FF" />
+              </linearGradient>
+            </defs>
+            <XAxis dataKey="day" tickLine={false} axisLine={false} />
+            <YAxis tickLine={false} axisLine={false} width={40} />
+            <Bar dataKey="total">
+              {chartData.map((d, idx) => (
+                <Cell
+                  key={d.day}
+                  cursor="pointer"
+                  fill="url(#earningsGradient)"
+                  fillOpacity={hoveredBar === idx ? 0 : 1}
+                  onMouseEnter={() => setHoveredBar(idx)}
+                  onMouseLeave={() => setHoveredBar(null)}
+                  onClick={() => {
+                    setSelectedDate(d.fullDate)
+                    setHoveredBar(null)
+                  }}
+                />
+              ))}
+            </Bar>
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  formatter={(value) => formatCurrency(value as number)}
+                />
+              }
+            />
+          </BarChart>
+        </ChartContainer>
+
+        {selectedDate && (
+          <div className="flex items-center justify-between">
+            <h3 className="font-medium">
+              {new Date(selectedDate).toLocaleDateString("nl-NL", {
+                weekday: "long",
+                month: "long",
+                day: "numeric",
+              })}
+            </h3>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSelectedDate(null)}
+            >
+              <X className="h-4 w-4 mr-1" /> Back to month
+            </Button>
           </div>
         )}
-      </CardHeader>
-      <CardContent>
+
+        <div className="flex flex-col gap-4 md:flex-row md:items-center">
+          <Select value={chatterFilter} onValueChange={setChatterFilter}>
+            <SelectTrigger className="w-[200px]">
+              <User className="h-4 w-4 text-muted-foreground" />
+              <SelectValue placeholder="All chatters" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All chatters</SelectItem>
+              {chatters.map((chatter) => (
+                <SelectItem key={chatter.id} value={chatter.id}>
+                  {chatter.full_name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={typeFilter} onValueChange={setTypeFilter}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="All types" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All types</SelectItem>
+              <SelectItem value="paypermessage">Pay per message</SelectItem>
+              <SelectItem value="tip">Tip</SelectItem>
+              <SelectItem value="subscriptionperiod">
+                Subscription period
+              </SelectItem>
+              <SelectItem value="payperpost">Pay per post</SelectItem>
+            </SelectContent>
+          </Select>
+          <Dialog open={syncOpen} onOpenChange={setSyncOpen}>
+            <DialogTrigger asChild>
+              <Button className="md:ml-auto">Sync Earnings</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Sync Earnings</DialogTitle>
+                <DialogDescription>
+                  Select the start and end date times.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="sync-from">From</Label>
+                  <Input
+                    id="sync-from"
+                    type="datetime-local"
+                    value={syncFrom}
+                    onChange={(e) => setSyncFrom(e.target.value)}
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="sync-to">To</Label>
+                  <Input
+                    id="sync-to"
+                    type="datetime-local"
+                    value={syncTo}
+                    onChange={(e) => setSyncTo(e.target.value)}
+                  />
+                </div>
+              </div>
+              <DialogFooter>
+                <Button variant="secondary" onClick={() => setSyncOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={async () => {
+                    await handleSync()
+                    setSyncOpen(false)
+                  }}
+                >
+                  Sync
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+
         <Table>
           <TableHeader>
             <TableRow>
@@ -329,7 +485,7 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {earnings.map((earning) => (
+            {paginated.map((earning) => (
               <TableRow key={earning.id}>
                 <TableCell>
                   <div className="flex items-center gap-2">
@@ -340,39 +496,40 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
                 <TableCell>
                   {(() => {
                     const iconMap: Record<string, JSX.Element> = {
-                      paypermessage: <MessageSquare className="h-4 w-4 text-muted-foreground" />,
+                      paypermessage: (
+                        <MessageSquare className="h-4 w-4 text-muted-foreground" />
+                      ),
                       tip: <Gift className="h-4 w-4 text-muted-foreground" />,
-                      subscriptionperiod: <Repeat className="h-4 w-4 text-muted-foreground" />,
-                      payperpost: <FileText className="h-4 w-4 text-muted-foreground" />,
+                      subscriptionperiod: (
+                        <Repeat className="h-4 w-4 text-muted-foreground" />
+                      ),
+                      payperpost: (
+                        <FileText className="h-4 w-4 text-muted-foreground" />
+                      ),
                     }
                     return iconMap[earning.type] || null
                   })()}
                 </TableCell>
                 <TableCell>
                   {['paypermessage','tip'].includes(earning.type) ? (
-                    limit ? (
-                      <div className="flex items-center gap-2">
+                    <Select
+                      value={earning.chatterId ?? "unknown"}
+                      onValueChange={(value) =>
+                        handleChatterChange(earning.id, value)
+                      }
+                    >
+                      <SelectTrigger className="w-[200px]">
                         <User className="h-4 w-4 text-muted-foreground" />
-                        {earning.chatter?.full_name ?? "Wolf"}
-                      </div>
-                    ) : (
-                      <Select
-                        value={earning.chatterId ?? "unknown"}
-                        onValueChange={(value) => handleChatterChange(earning.id, value)}
-                      >
-                        <SelectTrigger className="w-[200px]">
-                          <User className="h-4 w-4 text-muted-foreground" />
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {chatters.map((chatter) => (
-                            <SelectItem key={chatter.id} value={chatter.id}>
-                              {chatter.full_name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    )
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {chatters.map((chatter) => (
+                          <SelectItem key={chatter.id} value={chatter.id}>
+                            {chatter.full_name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   ) : (
                     <span className="text-muted-foreground">—</span>
                   )}
@@ -384,24 +541,65 @@ export function EarningsOverview({ limit }: EarningsOverviewProps) {
                   </div>
                 </TableCell>
                 <TableCell>
-                  <span className="text-muted-foreground">{earning.description || "No description"}</span>
+                  <span className="text-muted-foreground">
+                    {earning.description || "No description"}
+                  </span>
                 </TableCell>
               </TableRow>
             ))}
           </TableBody>
         </Table>
-        {!limit && hasMore && <div ref={loadMoreRef} className="h-10" />}
-        {loadingMore && (
-          <p className="text-center py-2 text-sm text-muted-foreground">Loading...</p>
+
+        {pageCount > 1 && (
+          <Pagination className="pt-4">
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    setPage((p) => Math.max(1, p - 1))
+                  }}
+                />
+              </PaginationItem>
+              {Array.from({ length: pageCount }).map((_, i) => (
+                <PaginationItem key={i}>
+                  <PaginationLink
+                    href="#"
+                    isActive={page === i + 1}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      setPage(i + 1)
+                    }}
+                  >
+                    {i + 1}
+                  </PaginationLink>
+                </PaginationItem>
+              ))}
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    setPage((p) => Math.min(pageCount, p + 1))
+                  }}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
         )}
-        {earnings.length === 0 && (
+
+        {paginated.length === 0 && (
           <div className="text-center py-8 text-muted-foreground">
             <DollarSign className="h-12 w-12 mx-auto mb-4 opacity-50" />
             <p>No earnings recorded yet.</p>
-            <p className="text-sm">Earnings will appear here once chatters start logging them.</p>
+            <p className="text-sm">
+              Earnings will appear here once chatters start logging them.
+            </p>
           </div>
         )}
       </CardContent>
     </Card>
   )
 }
+

--- a/components/revenue-overview.tsx
+++ b/components/revenue-overview.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
+
 import {
   Card,
   CardContent,
@@ -8,84 +9,188 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
-import { api } from "@/lib/api"
 import { DollarSign, X } from "lucide-react"
+import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts"
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
+import { api } from "@/lib/api"
+
+interface RevenueEntry {
+  id: string
+  date: string
+  amount: number
+  modelCommissionRate: number
+  chatterCommissionRate: number
+}
+
+interface DailyData {
+  day: number
+  revenue: number
+  fullDate: string
+  entries: RevenueEntry[]
+}
 
 export function RevenueOverview() {
-  const [earnings, setEarnings] = useState<any[] | null>(null)
+  const [entries, setEntries] = useState<RevenueEntry[]>([])
   const [loading, setLoading] = useState(true)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [platformFee, setPlatformFee] = useState(20)
   const [adjustments, setAdjustments] = useState<number[]>([])
+  const [hoveredBar, setHoveredBar] = useState<number | null>(null)
 
   useEffect(() => {
-    const fetchEarnings = async () => {
+    const fetchRevenue = async () => {
       try {
         const data = await api.getRevenueEarnings()
-        setEarnings(data || [])
+        const formatted = (data || []).map((e: any) => ({
+          id: String(e.id),
+          date: e.date || e.created_at,
+          amount: Number(e.amount ?? 0),
+          modelCommissionRate: Number(
+            e.modelCommissionRate ?? e.model_commission_rate ?? 0,
+          ),
+          chatterCommissionRate: Number(
+            e.chatterCommissionRate ?? e.chatter_commission_rate ?? 0,
+          ),
+        }))
+        setEntries(formatted)
       } catch (err) {
         console.error("Failed to load revenue earnings:", err)
-        setEarnings([])
       } finally {
         setLoading(false)
       }
     }
-    fetchEarnings()
+    fetchRevenue()
   }, [])
 
-  const total = (earnings || []).reduce(
-      (sum: number, e: any) => sum + (e.amount || 0),
-      0
-  )
-  const platformFeeAmount = total * (platformFee / 100)
-  const afterPlatform = total - platformFeeAmount
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth()
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
 
-  let modelCommission = 0
-  let chatterCommission = 0
-  const monthlyMap = new Map<string, number>()
-  ;(earnings || []).forEach((e: any) => {
-    const amount = e.amount || 0
-    const net = amount * (1 - platformFee / 100)
-    const mRate =
-        e.modelCommissionRate ?? e.model_commission_rate ?? 0
-    const cRate =
-        e.chatterCommissionRate ?? e.chatter_commission_rate ?? 0
-    const mComm = net * (mRate / 100)
-    const cComm = net * (cRate / 100)
-    modelCommission += mComm
-    chatterCommission += cComm
-    const company = net - mComm - cComm
-    const date = new Date(e.date || e.created_at)
-    const key = `${date.getFullYear()}-${String(
-        date.getMonth() + 1
-    ).padStart(2, "0")}`
-    monthlyMap.set(key, (monthlyMap.get(key) || 0) + company)
-  })
-
-  const monthlyEntries = Array.from(monthlyMap.entries()).sort(
-      (a, b) => a[0].localeCompare(b[0])
+  const monthlyEntries = useMemo(
+    () =>
+      entries.filter((e) => {
+        const d = new Date(e.date)
+        return d.getFullYear() === year && d.getMonth() === month
+      }),
+    [entries, year, month],
   )
 
-  const companyRevenue = afterPlatform - modelCommission - chatterCommission
-  const adjustmentsTotal = adjustments.reduce((sum, val) => sum + (val || 0), 0)
+  const dailyData: DailyData[] = useMemo(() => {
+    return Array.from({ length: daysInMonth }, (_, i) => {
+      const day = i + 1
+      const fullDate = new Date(year, month, day)
+        .toISOString()
+        .split("T")[0]
+      const dayEntries = monthlyEntries.filter((e) =>
+        e.date.startsWith(fullDate),
+      )
+      const revenue = dayEntries.reduce((sum, e) => {
+        const amount = Number(e.amount)
+        const net = amount * (1 - platformFee / 100)
+        const mComm = net * (e.modelCommissionRate / 100)
+        const cComm = net * (e.chatterCommissionRate / 100)
+        return sum + (net - mComm - cComm)
+      }, 0)
+      return { day, revenue, fullDate, entries: dayEntries }
+    })
+  }, [monthlyEntries, daysInMonth, year, month, platformFee])
+
+  const monthTotals = useMemo(() => {
+    return monthlyEntries.reduce(
+      (acc, e) => {
+        const amount = Number(e.amount)
+        const net = amount * (1 - platformFee / 100)
+        const mComm = net * (e.modelCommissionRate / 100)
+        const cComm = net * (e.chatterCommissionRate / 100)
+        acc.total += amount
+        acc.platformFee += amount - net
+        acc.afterPlatform += net
+        acc.modelCommission += mComm
+        acc.chatterCommission += cComm
+        return acc
+      },
+      {
+        total: 0,
+        platformFee: 0,
+        afterPlatform: 0,
+        modelCommission: 0,
+        chatterCommission: 0,
+      },
+    )
+  }, [monthlyEntries, platformFee])
+
+  const companyRevenue =
+    monthTotals.afterPlatform -
+    monthTotals.modelCommission -
+    monthTotals.chatterCommission
+  const adjustmentsTotal = adjustments.reduce(
+    (sum, val) => sum + (val || 0),
+    0,
+  )
   const finalRevenue = companyRevenue + adjustmentsTotal
 
-  const formatCurrency = (amount: number) =>
-      new Intl.NumberFormat("nl-NL", {
-        style: "currency",
-        currency: "EUR",
-      }).format(amount)
+  const selectedEntries = selectedDate
+    ? dailyData.find((d) => d.fullDate === selectedDate)?.entries || []
+    : []
 
-  const formatMonth = (month: string) => {
-    const [year, m] = month.split("-")
-    const date = new Date(Number(year), Number(m) - 1)
-    return date.toLocaleDateString("nl-NL", {
+  const dayTotals = useMemo(() => {
+    return selectedEntries.reduce(
+      (acc, e) => {
+        const amount = Number(e.amount)
+        const net = amount * (1 - platformFee / 100)
+        const mComm = net * (e.modelCommissionRate / 100)
+        const cComm = net * (e.chatterCommissionRate / 100)
+        acc.total += amount
+        acc.platformFee += amount - net
+        acc.afterPlatform += net
+        acc.modelCommission += mComm
+        acc.chatterCommission += cComm
+        return acc
+      },
+      {
+        total: 0,
+        platformFee: 0,
+        afterPlatform: 0,
+        modelCommission: 0,
+        chatterCommission: 0,
+      },
+    )
+  }, [selectedEntries, platformFee])
+
+  const dayCompanyRevenue =
+    dayTotals.afterPlatform -
+    dayTotals.modelCommission -
+    dayTotals.chatterCommission
+
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat("nl-NL", {
+      style: "currency",
+      currency: "EUR",
+    }).format(Number.isFinite(amount) ? amount : 0)
+
+  const formatFullDate = (date: string) =>
+    new Date(date).toLocaleDateString("nl-NL", {
+      weekday: "long",
       month: "long",
-      year: "numeric",
+      day: "numeric",
     })
-  }
 
   const addAdjustment = () => setAdjustments([...adjustments, 0])
   const updateAdjustment = (index: number, value: number) => {
@@ -99,109 +204,236 @@ export function RevenueOverview() {
 
   if (loading) {
     return (
-        <Card>
-          <CardContent className="p-6">
-            <div className="animate-pulse space-y-4">
-              <div className="h-12 bg-muted rounded" />
-              <div className="h-12 bg-muted rounded" />
-              <div className="h-12 bg-muted rounded" />
-            </div>
-          </CardContent>
-        </Card>
+      <Card>
+        <CardContent className="p-6">
+          <div className="animate-pulse space-y-4">
+            <div className="h-12 bg-muted rounded" />
+            <div className="h-12 bg-muted rounded" />
+            <div className="h-12 bg-muted rounded" />
+          </div>
+        </CardContent>
+      </Card>
     )
   }
 
+  const chartConfig = {
+    revenue: {
+      label: "Revenue",
+      color: "#6CE8F2",
+    },
+  }
+
   return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <DollarSign className="h-5 w-5" />
-            Revenue Overview
-          </CardTitle>
-          <CardDescription>
-            Total revenue after platform, model and chatter commissions.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          {monthlyEntries.length > 0 && (
-              <div className="overflow-x-auto">
-                <div className="flex gap-4 pb-4">
-                  {monthlyEntries.map(([month, amount]) => (
-                      <div key={month} className="min-w-[100px] text-center">
-                        <div className="font-medium">{formatMonth(month)}</div>
-                        <div className="text-sm">{formatCurrency(amount)}</div>
-                      </div>
-                  ))}
-                </div>
-              </div>
-          )}
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="platform-fee">Platform fee (%)</Label>
-              <Input
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <DollarSign className="h-5 w-5" />
+          Revenue Overview
+        </CardTitle>
+        <CardDescription>
+          Company revenue for {" "}
+          {now.toLocaleDateString("nl-NL", { month: "long", year: "numeric" })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ChartContainer
+          config={chartConfig}
+          className="h-64 w-full aspect-auto"
+        >
+          <BarChart data={dailyData}>
+            <defs>
+              <linearGradient id="revenueGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#6CE8F2" />
+                <stop offset="100%" stopColor="#FFA6FF" />
+              </linearGradient>
+            </defs>
+            <XAxis dataKey="day" tickLine={false} axisLine={false} />
+            <YAxis tickLine={false} axisLine={false} width={40} />
+            <Bar dataKey="revenue">
+              {dailyData.map((d, idx) => (
+                <Cell
+                  key={d.day}
+                  cursor="pointer"
+                  fill="url(#revenueGradient)"
+                  fillOpacity={hoveredBar === idx ? 0 : 1}
+                  onMouseEnter={() => setHoveredBar(idx)}
+                  onMouseLeave={() => setHoveredBar(null)}
+                  onClick={() => {
+                    setSelectedDate(d.fullDate)
+                    setHoveredBar(null)
+                  }}
+                />
+              ))}
+            </Bar>
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  formatter={(value) => formatCurrency(value as number)}
+                />
+              }
+            />
+          </BarChart>
+        </ChartContainer>
+
+        {selectedDate ? (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="font-medium">{formatFullDate(selectedDate)}</h3>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSelectedDate(null)}
+              >
+                Back to month
+              </Button>
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Gross</TableHead>
+                  <TableHead>Model %</TableHead>
+                  <TableHead>Chatter %</TableHead>
+                  <TableHead className="text-right">Company</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {selectedEntries.map((e) => {
+                  const net = e.amount * (1 - platformFee / 100)
+                  const mComm = net * (e.modelCommissionRate / 100)
+                  const cComm = net * (e.chatterCommissionRate / 100)
+                  const company = net - mComm - cComm
+                  return (
+                    <TableRow key={e.id}>
+                      <TableCell>{formatCurrency(e.amount)}</TableCell>
+                      <TableCell>{e.modelCommissionRate}%</TableCell>
+                      <TableCell>{e.chatterCommissionRate}%</TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(company)}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+            {selectedEntries.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center">
+                  No entries
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+        <div className="space-y-2">
+          <div className="flex justify-between">
+            <span>Total earnings</span>
+            <span>{formatCurrency(dayTotals.total)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Platform fee ({platformFee}%)</span>
+            <span>-{formatCurrency(dayTotals.platformFee)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>After platform</span>
+            <span>{formatCurrency(dayTotals.afterPlatform)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Model commissions</span>
+            <span>-{formatCurrency(dayTotals.modelCommission)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Chatter commissions</span>
+            <span>-{formatCurrency(dayTotals.chatterCommission)}</span>
+          </div>
+          <div className="flex justify-between font-medium">
+            <span>Company revenue</span>
+            <span>{formatCurrency(dayCompanyRevenue)}</span>
+          </div>
+        </div>
+      </div>
+    ) : (
+      <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="platform-fee">Platform fee (%)</Label>
+                <Input
                   id="platform-fee"
                   type="number"
                   value={platformFee}
                   onChange={(e) => setPlatformFee(Number(e.target.value) || 0)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>Manual adjustments (negative = cost)</Label>
-              {adjustments.map((adj, idx) => (
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Manual adjustments (negative = cost)</Label>
+                {adjustments.map((adj, idx) => (
                   <div key={idx} className="flex items-center gap-2">
                     <Input
-                        type="number"
-                        value={adj}
-                        onChange={(e) => updateAdjustment(idx, Number(e.target.value) || 0)}
+                      type="number"
+                      value={adj}
+                      onChange={(e) =>
+                        updateAdjustment(idx, Number(e.target.value) || 0)
+                      }
                     />
-                    <Button variant="outline" size="icon" onClick={() => removeAdjustment(idx)}>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => removeAdjustment(idx)}
+                    >
                       <X className="h-4 w-4" />
                     </Button>
                   </div>
-              ))}
-              <Button variant="outline" onClick={addAdjustment} className="w-full">
-                Add adjustment
-              </Button>
+                ))}
+                <Button
+                  variant="outline"
+                  onClick={addAdjustment}
+                  className="w-full"
+                >
+                  Add adjustment
+                </Button>
+              </div>
             </div>
-          </div>
 
-          <div className="space-y-2">
-            <div className="flex justify-between">
-              <span>Total earnings</span>
-              <span>{formatCurrency(total)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>Platform fee ({platformFee}%)</span>
-              <span>-{formatCurrency(platformFeeAmount)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>After platform</span>
-              <span>{formatCurrency(afterPlatform)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>Model commissions</span>
-              <span>-{formatCurrency(modelCommission)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>Chatter commissions</span>
-              <span>-{formatCurrency(chatterCommission)}</span>
-            </div>
-            <div className="flex justify-between font-medium">
-              <span>Company revenue</span>
-              <span>{formatCurrency(companyRevenue)}</span>
-            </div>
-            {adjustmentsTotal !== 0 && (
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span>Total earnings</span>
+                <span>{formatCurrency(monthTotals.total)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Platform fee ({platformFee}%)</span>
+                <span>-{formatCurrency(monthTotals.platformFee)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>After platform</span>
+                <span>{formatCurrency(monthTotals.afterPlatform)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Model commissions</span>
+                <span>-{formatCurrency(monthTotals.modelCommission)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Chatter commissions</span>
+                <span>-{formatCurrency(monthTotals.chatterCommission)}</span>
+              </div>
+              <div className="flex justify-between font-medium">
+                <span>Company revenue</span>
+                <span>{formatCurrency(companyRevenue)}</span>
+              </div>
+              {adjustmentsTotal !== 0 && (
                 <div className="flex justify-between">
                   <span>Adjustments</span>
-                  <span>{adjustmentsTotal >= 0 ? "+" : ""}{formatCurrency(adjustmentsTotal)}</span>
+                  <span>
+                    {adjustmentsTotal >= 0 ? "+" : ""}
+                    {formatCurrency(adjustmentsTotal)}
+                  </span>
                 </div>
-            )}
-            <div className="flex justify-between font-bold">
-              <span>Final revenue</span>
-              <span>{formatCurrency(finalRevenue)}</span>
+              )}
+              <div className="flex justify-between font-bold">
+                <span>Final revenue</span>
+                <span>{formatCurrency(finalRevenue)}</span>
+              </div>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        )}
+      </CardContent>
+    </Card>
   )
 }
+


### PR DESCRIPTION
## Summary
- restore original earnings overview table
- display daily revenue in a full-width bar chart with logo colors and hover-to-hide interaction
- add per-day revenue breakdown with monthly-style summary and Back to month button
- normalize revenue values and guard currency formatter to prevent NaN totals
- embed a daily earnings chart above the earnings list and replace infinite scroll with pagination

## Testing
- `npm run lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c1249460688327b18c9cf88ee5000f