### PR TITLE
feat: add tiered earnings filters and shift support

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -147,14 +147,32 @@ class ApiClient {
   }
 
   /* ---------- Employee Earnings ---------- */
-  getEmployeeEarnings(params?: { limit?: number; offset?: number; chatterId?: string; type?: string; modelId?: string; date?: string }) {
+  getEmployeeEarnings(params?: {
+    limit?: number
+    offset?: number
+    chatterId?: string
+    type?: string
+    types?: string[]
+    modelId?: string
+    shiftId?: string
+    date?: string
+    from?: string
+    to?: string
+  }) {
     const search = new URLSearchParams()
     if (params?.limit !== undefined) search.set("limit", String(params.limit))
     if (params?.offset !== undefined) search.set("offset", String(params.offset))
     if (params?.chatterId) search.set("chatterId", params.chatterId)
-    if (params?.type) search.set("type", params.type)
+    if (params?.types?.length) {
+      params.types.forEach((type) => search.append("type", type))
+    } else if (params?.type) {
+      search.set("type", params.type)
+    }
     if (params?.modelId) search.set("modelId", params.modelId)
+    if (params?.shiftId) search.set("shiftId", params.shiftId)
     if (params?.date) search.set("date", params.date)
+    if (params?.from) search.set("from", params.from)
+    if (params?.to) search.set("to", params.to)
     const query = search.toString() ? `?${search.toString()}` : ""
     return this.request(`/employee-earnings${query}`)
   }
@@ -164,16 +182,27 @@ class ApiClient {
     offset: number
     chatterId?: string
     type?: string
+    types?: string[]
     modelId?: string
+    shiftId?: string
     date?: string
+    from?: string
+    to?: string
   }) {
     const search = new URLSearchParams()
     search.set("limit", String(params.limit))
     search.set("offset", String(params.offset))
     if (params.chatterId) search.set("chatterId", params.chatterId)
-    if (params.type) search.set("type", params.type)
+    if (params.types?.length) {
+      params.types.forEach((type) => search.append("type", type))
+    } else if (params.type) {
+      search.set("type", params.type)
+    }
     if (params.modelId) search.set("modelId", params.modelId)
+    if (params.shiftId) search.set("shiftId", params.shiftId)
     if (params.date) search.set("date", params.date)
+    if (params.from) search.set("from", params.from)
+    if (params.to) search.set("to", params.to)
     const query = `?${search.toString()}`
 
     const response = await fetch(`${API_BASE_URL}/employee-earnings${query}`, {
@@ -203,12 +232,28 @@ class ApiClient {
     return this.request(`/employee-earnings/${id}`)
   }
 
-  getTotalCount(params?: { chatterId?: string; type?: string; modelId?: string; date?: string }) {
+  getTotalCount(params?: {
+    chatterId?: string
+    type?: string
+    types?: string[]
+    modelId?: string
+    shiftId?: string
+    date?: string
+    from?: string
+    to?: string
+  }) {
     const search = new URLSearchParams()
     if (params?.chatterId) search.set("chatterId", params.chatterId)
-    if (params?.type) search.set("type", params.type)
+    if (params?.types?.length) {
+      params.types.forEach((type) => search.append("type", type))
+    } else if (params?.type) {
+      search.set("type", params.type)
+    }
     if (params?.modelId) search.set("modelId", params.modelId)
+    if (params?.shiftId) search.set("shiftId", params.shiftId)
     if (params?.date) search.set("date", params.date)
+    if (params?.from) search.set("from", params.from)
+    if (params?.to) search.set("to", params.to)
     const query = search.toString() ? `?${search.toString()}` : ""
     return this.request(`/employee-earnings/totalCount${query}`)
   }


### PR DESCRIPTION
## Summary
- replace the earnings filters with a tiered dropdown that supports shift, model, chatter and multi-item selections plus clearer summaries
- refactor earnings data loading to split chart/list fetches, honour day selections without touching the chart data and show the selected shift in tables
- extend the API client helpers so callers can pass shift ids, multi-type filters and date ranges for totals or paginated data

## Testing
- pnpm lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c925134c548327b74ba09e3b29b639