### PR TITLE
Update shift calendar loading and editing

### DIFF
--- a/components/shift-manager.tsx
+++ b/components/shift-manager.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -20,7 +20,18 @@ import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
-import { Calendar, Clock, Plus, User, ChevronLeft, ChevronRight, Trash2, ChevronsUpDown, Check } from "lucide-react"
+import {
+    Calendar,
+    Clock,
+    Plus,
+    User,
+    ChevronLeft,
+    ChevronRight,
+    Trash2,
+    ChevronsUpDown,
+    Check,
+    Pencil,
+} from "lucide-react"
 import { api } from "@/lib/api"
 import { cn } from "@/lib/utils"
 import {
@@ -33,6 +44,7 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import { Switch } from "@/components/ui/switch"
 
 interface Shift {
     id: string
@@ -44,6 +56,9 @@ interface Shift {
     chatter: {
         full_name: string
     }
+    model_ids: string[]
+    model_names: string[]
+    date: string
 }
 
 interface Chatter {
@@ -60,13 +75,28 @@ export function ShiftManager() {
     const [shifts, setShifts] = useState<Shift[]>([])
     const [chatters, setChatters] = useState<Chatter[]>([])
     const [models, setModels] = useState<Model[]>([])
+    const [chatterNameMap, setChatterNameMap] = useState<Record<string, string>>({})
+    const [modelNameMap, setModelNameMap] = useState<Record<string, string>>({})
     const [loading, setLoading] = useState(true)
+    const [metaLoaded, setMetaLoaded] = useState(false)
     const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
     const [currentWeek, setCurrentWeek] = useState(new Date())
     const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
     const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
     const [newShift, setNewShift] = useState({
-        model_id: "",
+        chatter_id: "",
+        model_ids: [] as string[],
+        date: "",
+        start_hour: "",
+        start_minute: "",
+        end_hour: "",
+        end_minute: "",
+        repeatWeekly: false,
+        repeatWeeks: "",
+    })
+    const [isModelPopoverOpen, setIsModelPopoverOpen] = useState(false)
+    const [editingShift, setEditingShift] = useState<Shift | null>(null)
+    const [editShiftValues, setEditShiftValues] = useState({
         chatter_id: "",
         model_ids: [] as string[],
         date: "",
@@ -75,87 +105,232 @@ export function ShiftManager() {
         end_hour: "",
         end_minute: "",
     })
-    const [isModelPopoverOpen, setIsModelPopoverOpen] = useState(false)
+    const [isEditModelPopoverOpen, setIsEditModelPopoverOpen] = useState(false)
+    const loadedRangeKeysRef = useRef<Set<string>>(new Set())
 
-    useEffect(() => {
-        fetchData()
+    const formatDate = useCallback((date: Date) => {
+        return date.toISOString().split("T")[0]
     }, [])
 
-    const fetchData = async () => {
+    const getStartOfWeek = useCallback((date: Date) => {
+        const start = new Date(date)
+        const day = start.getDay()
+        const diff = start.getDate() - day + (day === 0 ? -6 : 1)
+        start.setDate(diff)
+        start.setHours(0, 0, 0, 0)
+        return start
+    }, [])
+
+    const getWeekDays = useCallback(
+        (date: Date) => {
+            const week = []
+            const startOfWeek = getStartOfWeek(date)
+
+            for (let i = 0; i < 7; i++) {
+                const day = new Date(startOfWeek)
+                day.setDate(startOfWeek.getDate() + i)
+                week.push(day)
+            }
+            return week
+        },
+        [getStartOfWeek]
+    )
+
+    const fetchMeta = useCallback(async () => {
         try {
-            const [shiftsData, chattersData, usersData, modelsData] = await Promise.all([
-                api.getShifts(),
+            const [chattersData, usersData, modelsData] = await Promise.all([
                 api.getChatters(),
                 api.getUsers(),
                 api.getModels(),
             ])
-            console.log(shiftsData)
 
             const userMap = new Map((usersData || []).map((u: any) => [String(u.id), u.fullName || ""]))
 
             const chattersWithNames = (chattersData || []).map((c: any) => ({
-                ...c,
+                id: String(c.id),
                 full_name: userMap.get(String(c.id)) || "",
             }))
 
-            const chatterMap = new Map((chattersWithNames || []).map((c: any) => [String(c.id), c.full_name]))
+            const chatterLookup: Record<string, string> = {}
+            chattersWithNames.forEach((chatter) => {
+                chatterLookup[chatter.id] = chatter.full_name || "Unknown"
+            })
 
-            const formattedShifts = (shiftsData || []).map((shift: any) => ({
-                id: String(shift.id),
-                chatter_id: String(shift.chatterId),
-                start_time: shift.startTime,
-                end_time: shift.endTime,
-                status: shift.status,
-                created_at: shift.createdAt,
-                chatter: { full_name: chatterMap.get(String(shift.chatterId)) || "Unknown" },
+            const modelsList = (modelsData || []).map((m: any) => ({
+                id: String(m.id),
+                display_name: m.displayName,
             }))
 
-            setShifts(formattedShifts)
-            setChatters(
-                (chattersData || []).map((c: any) => ({
-                    id: String(c.id),
-                    full_name: userMap.get(String(c.id)) || "",
-                })),
-            )
-            setModels(
-                (modelsData || []).map((m: any) => ({
-                    id: String(m.id),
-                    display_name: m.displayName,
-                })),
-            )
+            const modelLookup: Record<string, string> = {}
+            modelsList.forEach((model) => {
+                modelLookup[model.id] = model.display_name || "Unknown Model"
+            })
+
+            setChatters(chattersWithNames)
+            setModels(modelsList)
+            setChatterNameMap(chatterLookup)
+            setModelNameMap(modelLookup)
         } catch (error) {
-            console.error("Error fetching shifts:", error)
+            console.error("Error loading shift metadata:", error)
+            setChatters([])
+            setModels([])
+            setChatterNameMap({})
+            setModelNameMap({})
         } finally {
-            setLoading(false)
+            setMetaLoaded(true)
         }
-    }
+    }, [])
 
-    const getWeekDays = (date: Date) => {
-        const week = []
-        const startOfWeek = new Date(date)
-        const day = startOfWeek.getDay()
-        const diff = startOfWeek.getDate() - day + (day === 0 ? -6 : 1) // Monday as first day
-        startOfWeek.setDate(diff)
+    const loadWeek = useCallback(
+        async (
+            targetDate: Date,
+            options?: { prefetch?: boolean; force?: boolean; silent?: boolean },
+        ) => {
+            const { prefetch = false, force = false, silent = false } = options || {}
+            const weekStart = getStartOfWeek(targetDate)
+            const rangeStart = new Date(weekStart)
+            const rangeEnd = new Date(weekStart)
+            rangeEnd.setDate(rangeEnd.getDate() + 13)
 
-        for (let i = 0; i < 7; i++) {
-            const day = new Date(startOfWeek)
-            day.setDate(startOfWeek.getDate() + i)
-            week.push(day)
-        }
-        return week
-    }
+            const from = formatDate(rangeStart)
+            const to = formatDate(rangeEnd)
+            const rangeKey = `${from}_${to}`
+
+            if (!force && loadedRangeKeysRef.current.has(rangeKey)) {
+                if (!prefetch && !silent) {
+                    setLoading(false)
+                    const nextWeek = new Date(weekStart)
+                    nextWeek.setDate(nextWeek.getDate() + 7)
+                    void loadWeek(nextWeek, { prefetch: true })
+                }
+                return
+            }
+
+            if (!prefetch && !silent) {
+                setLoading(true)
+            }
+
+            try {
+                const shiftsData = await api.getShifts({
+                    from,
+                    to,
+                })
+
+                const formattedShifts = (shiftsData || []).map((shift: any) => {
+                    const modelIds = (shift.modelIds || []).map((id: any) => String(id))
+                    const startDate = shift.startTime
+                        ? String(shift.startTime).slice(0, 10)
+                        : String(shift.date)
+
+                    return {
+                        id: String(shift.id),
+                        chatter_id: String(shift.chatterId),
+                        start_time: shift.startTime,
+                        end_time: shift.endTime,
+                        status: shift.status,
+                        created_at: shift.createdAt,
+                        chatter: {
+                            full_name:
+                                chatterNameMap[String(shift.chatterId)] || "Unknown",
+                        },
+                        model_ids: modelIds,
+                        model_names: modelIds.map(
+                            (modelId) => modelNameMap[modelId] || "Unknown Model",
+                        ),
+                        date: startDate,
+                    }
+                })
+
+                setShifts((prev) => {
+                    const base = force
+                        ? prev.filter((shift) => shift.date < from || shift.date > to)
+                        : prev
+                    const merged = new Map(base.map((shift) => [shift.id, shift]))
+                    formattedShifts.forEach((shift) => merged.set(shift.id, shift))
+                    return Array.from(merged.values())
+                })
+
+                loadedRangeKeysRef.current.add(rangeKey)
+
+                if (!prefetch && !silent) {
+                    setLoading(false)
+                    const nextWeek = new Date(weekStart)
+                    nextWeek.setDate(nextWeek.getDate() + 7)
+                    void loadWeek(nextWeek, { prefetch: true })
+                }
+            } catch (error) {
+                console.error("Error loading shifts:", error)
+                if (!prefetch && !silent) {
+                    setLoading(false)
+                }
+            }
+        },
+        [chatterNameMap, formatDate, getStartOfWeek, modelNameMap]
+    )
+
+    useEffect(() => {
+        setLoading(true)
+        void fetchMeta()
+    }, [fetchMeta])
+
+    useEffect(() => {
+        if (!metaLoaded) return
+        loadedRangeKeysRef.current.clear()
+        setShifts([])
+        setLoading(true)
+        void loadWeek(currentWeek, { force: true })
+    }, [metaLoaded, loadWeek])
+
+    useEffect(() => {
+        if (!metaLoaded) return
+        void loadWeek(currentWeek)
+    }, [currentWeek, metaLoaded, loadWeek])
 
     const getShiftsForDay = (date: Date) => {
-        const dayStart = new Date(date)
-        dayStart.setHours(0, 0, 0, 0)
-        const dayEnd = new Date(date)
-        dayEnd.setHours(23, 59, 59, 999)
-
-        return shifts.filter((shift) => {
-            const shiftStart = new Date(shift.start_time)
-            return shiftStart >= dayStart && shiftStart <= dayEnd
-        })
+        const dateStr = formatDate(date)
+        return shifts
+            .filter((shift) => shift.date === dateStr)
+            .slice()
+            .sort(
+                (a, b) =>
+                    new Date(a.start_time).getTime() - new Date(b.start_time).getTime(),
+            )
     }
+
+    const currentWeekBounds = useMemo(() => {
+        const start = getStartOfWeek(currentWeek)
+        start.setHours(0, 0, 0, 0)
+        const end = new Date(start)
+        end.setDate(end.getDate() + 6)
+        end.setHours(23, 59, 59, 999)
+        return {
+            start,
+            end,
+        }
+    }, [currentWeek, getStartOfWeek])
+
+    const { start: currentWeekStart, end: currentWeekEnd } = currentWeekBounds
+
+    const currentWeekShifts = useMemo(
+        () =>
+            shifts
+                .filter(
+                    (shift) => {
+                        const shiftDate = new Date(`${shift.date}T00:00:00`)
+                        return (
+                            shiftDate >= currentWeekStart &&
+                            shiftDate <= currentWeekEnd
+                        )
+                    },
+                )
+                .slice()
+                .sort(
+                    (a, b) =>
+                        new Date(a.start_time).getTime() -
+                        new Date(b.start_time).getTime(),
+                ),
+        [shifts, currentWeekEnd, currentWeekStart],
+    )
 
     const navigateWeek = (direction: "prev" | "next") => {
         const newWeek = new Date(currentWeek)
@@ -181,17 +356,25 @@ export function ShiftManager() {
 
             const endDateTime = `${endDate}T${newShift.end_hour}:${newShift.end_minute}:00`
 
-            await api.createShift({
+            const payload: Record<string, unknown> = {
                 chatterId: newShift.chatter_id,
                 modelIds: newShift.model_ids,
                 start_time: startDateTime,
                 end_time: endDateTime,
                 date: newShift.date,
                 status: "scheduled",
-            })
+            }
+
+            if (newShift.repeatWeekly) {
+                payload.repeatWeekly = true
+                payload.repeatWeeks = Number(newShift.repeatWeeks)
+            }
+
+            await api.createShift(payload)
+
+            const createdShiftDate = newShift.date ? new Date(newShift.date) : null
 
             setNewShift({
-                model_id: "",
                 chatter_id: "",
                 model_ids: [],
                 date: "",
@@ -199,20 +382,137 @@ export function ShiftManager() {
                 start_minute: "",
                 end_hour: "",
                 end_minute: "",
+                repeatWeekly: false,
+                repeatWeeks: "",
             })
+            setIsModelPopoverOpen(false)
             setIsAddDialogOpen(false)
-            fetchData()
+
+            if (createdShiftDate) {
+                await loadWeek(createdShiftDate, { force: true, silent: true })
+            }
         } catch (error) {
             console.error("Error adding shift:", error)
         }
     }
 
     const updateShiftStatus = async (shiftId: string, newStatus: string) => {
+        const targetShift = shifts.find((shift) => shift.id === shiftId)
+        if (!targetShift) return
+
+        const previousStatus = targetShift.status
+        setShifts((prev) =>
+            prev.map((shift) => (shift.id === shiftId ? { ...shift, status: newStatus } : shift)),
+        )
+
         try {
             await api.updateShift(shiftId, { status: newStatus })
-            fetchData()
+            const shiftDate = targetShift.date
+            if (shiftDate) {
+                await loadWeek(new Date(`${shiftDate}T00:00:00`), { force: true, silent: true })
+            }
         } catch (error) {
             console.error("Error updating shift status:", error)
+            setShifts((prev) =>
+                prev.map((shift) => (shift.id === shiftId ? { ...shift, status: previousStatus } : shift)),
+            )
+        }
+    }
+
+    const openEditDialog = (shift: Shift) => {
+        const start = new Date(shift.start_time)
+        const end = new Date(shift.end_time)
+        const pad = (value: number) => value.toString().padStart(2, "0")
+
+        setEditShiftValues({
+            chatter_id: shift.chatter_id,
+            model_ids: [...shift.model_ids],
+            date: shift.date || start.toISOString().split("T")[0],
+            start_hour: pad(start.getHours()),
+            start_minute: pad(start.getMinutes()),
+            end_hour: pad(end.getHours()),
+            end_minute: pad(end.getMinutes()),
+        })
+        setEditingShift(shift)
+        setIsEditModelPopoverOpen(false)
+    }
+
+    const closeEditDialog = () => {
+        setEditingShift(null)
+        setEditShiftValues({
+            chatter_id: "",
+            model_ids: [],
+            date: "",
+            start_hour: "",
+            start_minute: "",
+            end_hour: "",
+            end_minute: "",
+        })
+        setIsEditModelPopoverOpen(false)
+    }
+
+    const handleUpdateShift = async (e: React.FormEvent) => {
+        e.preventDefault()
+        if (!editingShift) return
+
+        try {
+            const startDateTime = `${editShiftValues.date}T${editShiftValues.start_hour}:${editShiftValues.start_minute}:00`
+            let endDate = editShiftValues.date
+
+            if (
+                parseInt(editShiftValues.end_hour) < parseInt(editShiftValues.start_hour) ||
+                (parseInt(editShiftValues.end_hour) === parseInt(editShiftValues.start_hour) &&
+                    parseInt(editShiftValues.end_minute) <= parseInt(editShiftValues.start_minute))
+            ) {
+                const nextDay = new Date(editShiftValues.date)
+                nextDay.setDate(nextDay.getDate() + 1)
+                endDate = nextDay.toISOString().split("T")[0]
+            }
+
+            const endDateTime = `${endDate}T${editShiftValues.end_hour}:${editShiftValues.end_minute}:00`
+
+            const shiftId = editingShift.id
+            const previousDate = editingShift.date
+
+            setShifts((prev) =>
+                prev.map((shift) =>
+                    shift.id === shiftId
+                        ? {
+                              ...shift,
+                              chatter_id: editShiftValues.chatter_id,
+                              chatter: {
+                                  full_name:
+                                      chatterNameMap[editShiftValues.chatter_id] ||
+                                      shift.chatter.full_name,
+                              },
+                              model_ids: [...editShiftValues.model_ids],
+                              model_names: editShiftValues.model_ids.map(
+                                  (modelId) => modelNameMap[modelId] || "Unknown Model",
+                              ),
+                              start_time: startDateTime,
+                              end_time: endDateTime,
+                              date: editShiftValues.date,
+                          }
+                        : shift,
+                ),
+            )
+
+            await api.updateShift(shiftId, {
+                chatterId: editShiftValues.chatter_id,
+                modelIds: editShiftValues.model_ids,
+                start_time: startDateTime,
+                end_time: endDateTime,
+                date: editShiftValues.date,
+            })
+
+            await loadWeek(new Date(`${editShiftValues.date}T00:00:00`), { force: true, silent: true })
+            if (previousDate && previousDate !== editShiftValues.date) {
+                await loadWeek(new Date(`${previousDate}T00:00:00`), { force: true, silent: true })
+            }
+
+            closeEditDialog()
+        } catch (error) {
+            console.error("Error updating shift:", error)
         }
     }
 
@@ -361,9 +661,7 @@ export function ShiftManager() {
                                             <div
                                                 key={shift.id}
                                                 className={`text-xs p-2 rounded border-l-2 cursor-pointer relative group ${getShiftBlockColor(shift.status)}`}
-                                                onClick={() =>
-                                                    updateShiftStatus(shift.id, shift.status === "scheduled" ? "active" : shift.status)
-                                                }
+                                                onClick={() => openEditDialog(shift)}
                                             >
                                                 <div className="font-medium truncate">{shift.chatter.full_name}</div>
                                                 <div className="text-xs opacity-75">
@@ -396,7 +694,7 @@ export function ShiftManager() {
                             )
                         })}
                     </div>
-                    {shifts.length === 0 && (
+                    {currentWeekShifts.length === 0 && (
                         <div className="text-center py-8 text-muted-foreground">
                             <Calendar className="h-12 w-12 mx-auto mb-4 opacity-50" />
                             <p>Geen shifts ingepland.</p>
@@ -614,6 +912,44 @@ export function ShiftManager() {
                                         </div>
                                     </div>
 
+                                    <div className="flex items-start justify-between gap-4 rounded-md border p-3">
+                                        <div>
+                                            <p className="text-sm font-medium">Wekelijks herhalen</p>
+                                            <p className="text-xs text-muted-foreground">
+                                                Plan deze shift automatisch voor meerdere weken.
+                                            </p>
+                                        </div>
+                                        <Switch
+                                            checked={newShift.repeatWeekly}
+                                            onCheckedChange={(checked) =>
+                                                setNewShift((prev) => ({
+                                                    ...prev,
+                                                    repeatWeekly: checked,
+                                                    repeatWeeks: checked ? prev.repeatWeeks || "1" : "",
+                                                }))
+                                            }
+                                        />
+                                    </div>
+
+                                    {newShift.repeatWeekly && (
+                                        <div>
+                                            <Label htmlFor="repeat-weeks">Aantal weken</Label>
+                                            <Input
+                                                id="repeat-weeks"
+                                                type="number"
+                                                min={1}
+                                                value={newShift.repeatWeeks}
+                                                onChange={(e) =>
+                                                    setNewShift({ ...newShift, repeatWeeks: e.target.value })
+                                                }
+                                                required={newShift.repeatWeekly}
+                                            />
+                                            <p className="mt-1 text-xs text-muted-foreground">
+                                                Inclusief deze week. Geef aan voor hoeveel opeenvolgende weken de shift wordt ingepland.
+                                            </p>
+                                        </div>
+                                    )}
+
                                     <Button
                                         type="submit"
                                         className="w-full"
@@ -624,10 +960,244 @@ export function ShiftManager() {
                                             !newShift.start_hour ||
                                             !newShift.start_minute ||
                                             !newShift.end_hour ||
-                                            !newShift.end_minute
+                                            !newShift.end_minute ||
+                                            (newShift.repeatWeekly && (!newShift.repeatWeeks || Number(newShift.repeatWeeks) < 1))
                                         }
                                     >
                                         Shift Inplannen
+                                    </Button>
+                                </form>
+                            </DialogContent>
+                        </Dialog>
+                        <Dialog open={!!editingShift} onOpenChange={(open) => (!open ? closeEditDialog() : undefined)}>
+                            <DialogContent className="max-w-md">
+                                <DialogHeader>
+                                    <DialogTitle>Shift bewerken</DialogTitle>
+                                    <DialogDescription>Pas chatter, models en tijden aan.</DialogDescription>
+                                </DialogHeader>
+                                <form onSubmit={handleUpdateShift} className="space-y-4">
+                                    <div>
+                                        <Label htmlFor="edit-chatter">Chatter</Label>
+                                        <Select
+                                            value={editShiftValues.chatter_id}
+                                            onValueChange={(value) =>
+                                                setEditShiftValues({ ...editShiftValues, chatter_id: value })
+                                            }
+                                        >
+                                            <SelectTrigger id="edit-chatter">
+                                                <SelectValue placeholder="Selecteer een chatter" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {chatters.map((chatter) => (
+                                                    <SelectItem key={chatter.id} value={chatter.id}>
+                                                        {chatter.full_name}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    </div>
+
+                                    <div>
+                                        <Label htmlFor="edit-models">Models</Label>
+                                        <Popover
+                                            modal
+                                            open={isEditModelPopoverOpen}
+                                            onOpenChange={setIsEditModelPopoverOpen}
+                                        >
+                                            <PopoverTrigger asChild>
+                                                <Button
+                                                    id="edit-models"
+                                                    variant="outline"
+                                                    role="combobox"
+                                                    aria-expanded={isEditModelPopoverOpen}
+                                                    className="w-full justify-between bg-transparent"
+                                                >
+                                                    {editShiftValues.model_ids.length > 0
+                                                        ? `${editShiftValues.model_ids.length} model${
+                                                              editShiftValues.model_ids.length > 1 ? "s" : ""
+                                                          } geselecteerd`
+                                                        : "Selecteer models..."}
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </PopoverTrigger>
+                                            <PopoverContent portalled={false} className="w-full p-0">
+                                                <Command>
+                                                    <CommandInput placeholder="Zoek models..." />
+                                                    <CommandEmpty>Geen models gevonden.</CommandEmpty>
+                                                    <CommandList>
+                                                        <CommandGroup>
+                                                            {models.map((model) => (
+                                                                <CommandItem
+                                                                    key={model.id}
+                                                                    value={model.display_name}
+                                                                    onSelect={() => {
+                                                                        const isSelected = editShiftValues.model_ids.includes(model.id)
+                                                                        if (isSelected) {
+                                                                            setEditShiftValues({
+                                                                                ...editShiftValues,
+                                                                                model_ids: editShiftValues.model_ids.filter(
+                                                                                    (id) => id !== model.id,
+                                                                                ),
+                                                                            })
+                                                                        } else {
+                                                                            setEditShiftValues({
+                                                                                ...editShiftValues,
+                                                                                model_ids: [...editShiftValues.model_ids, model.id],
+                                                                            })
+                                                                        }
+                                                                    }}
+                                                                >
+                                                                    <Check
+                                                                        className={cn(
+                                                                            "mr-2 h-4 w-4",
+                                                                            editShiftValues.model_ids.includes(model.id)
+                                                                                ? "opacity-100"
+                                                                                : "opacity-0",
+                                                                        )}
+                                                                    />
+                                                                    {model.display_name}
+                                                                </CommandItem>
+                                                            ))}
+                                                        </CommandGroup>
+                                                    </CommandList>
+                                                </Command>
+                                            </PopoverContent>
+                                        </Popover>
+                                        {editShiftValues.model_ids.length > 0 && (
+                                            <div className="flex flex-wrap gap-1 mt-2">
+                                                {editShiftValues.model_ids.map((modelId) => {
+                                                    const model = models.find((m) => m.id === modelId)
+                                                    return (
+                                                        <Badge key={modelId} variant="secondary" className="text-xs">
+                                                            {model?.display_name}
+                                                            <button
+                                                                type="button"
+                                                                className="ml-1 hover:bg-muted-foreground/20 rounded-full"
+                                                                onClick={() =>
+                                                                    setEditShiftValues({
+                                                                        ...editShiftValues,
+                                                                        model_ids: editShiftValues.model_ids.filter((id) => id !== modelId),
+                                                                    })
+                                                                }
+                                                            >
+                                                                ×
+                                                            </button>
+                                                        </Badge>
+                                                    )
+                                                })}
+                                            </div>
+                                        )}
+                                    </div>
+
+                                    <div>
+                                        <Label htmlFor="edit-date">Datum</Label>
+                                        <Input
+                                            id="edit-date"
+                                            type="date"
+                                            value={editShiftValues.date}
+                                            onChange={(e) =>
+                                                setEditShiftValues({ ...editShiftValues, date: e.target.value })
+                                            }
+                                            required
+                                        />
+                                    </div>
+
+                                    <div className="grid grid-cols-2 gap-4">
+                                        <div>
+                                            <Label>Start Tijd</Label>
+                                            <div className="flex gap-2">
+                                                <Select
+                                                    value={editShiftValues.start_hour}
+                                                    onValueChange={(value) =>
+                                                        setEditShiftValues({ ...editShiftValues, start_hour: value })
+                                                    }
+                                                >
+                                                    <SelectTrigger className="flex-1">
+                                                        <SelectValue placeholder="Uur" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {generateTimeOptions("hour").map((option) => (
+                                                            <SelectItem key={option.value} value={option.value}>
+                                                                {option.value}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                                <Select
+                                                    value={editShiftValues.start_minute}
+                                                    onValueChange={(value) =>
+                                                        setEditShiftValues({ ...editShiftValues, start_minute: value })
+                                                    }
+                                                >
+                                                    <SelectTrigger className="flex-1">
+                                                        <SelectValue placeholder="Min" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {generateTimeOptions("minute").map((option) => (
+                                                            <SelectItem key={option.value} value={option.value}>
+                                                                {option.value}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                        </div>
+
+                                        <div>
+                                            <Label>Eind Tijd</Label>
+                                            <div className="flex gap-2">
+                                                <Select
+                                                    value={editShiftValues.end_hour}
+                                                    onValueChange={(value) =>
+                                                        setEditShiftValues({ ...editShiftValues, end_hour: value })
+                                                    }
+                                                >
+                                                    <SelectTrigger className="flex-1">
+                                                        <SelectValue placeholder="Uur" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {generateTimeOptions("hour").map((option) => (
+                                                            <SelectItem key={option.value} value={option.value}>
+                                                                {option.value}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                                <Select
+                                                    value={editShiftValues.end_minute}
+                                                    onValueChange={(value) =>
+                                                        setEditShiftValues({ ...editShiftValues, end_minute: value })
+                                                    }
+                                                >
+                                                    <SelectTrigger className="flex-1">
+                                                        <SelectValue placeholder="Min" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {generateTimeOptions("minute").map((option) => (
+                                                            <SelectItem key={option.value} value={option.value}>
+                                                                {option.value}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <Button
+                                        type="submit"
+                                        className="w-full"
+                                        disabled={
+                                            editShiftValues.model_ids.length === 0 ||
+                                            !editShiftValues.chatter_id ||
+                                            !editShiftValues.date ||
+                                            !editShiftValues.start_hour ||
+                                            !editShiftValues.start_minute ||
+                                            !editShiftValues.end_hour ||
+                                            !editShiftValues.end_minute
+                                        }
+                                    >
+                                        Shift Opslaan
                                     </Button>
                                 </form>
                             </DialogContent>
@@ -640,6 +1210,7 @@ export function ShiftManager() {
                         <TableHeader>
                             <TableRow>
                                 <TableHead>Chatter</TableHead>
+                                <TableHead>Models</TableHead>
                                 <TableHead>Start Tijd</TableHead>
                                 <TableHead>Eind Tijd</TableHead>
                                 <TableHead>Status</TableHead>
@@ -647,12 +1218,26 @@ export function ShiftManager() {
                             </TableRow>
                         </TableHeader>
                         <TableBody>
-                            {shifts.map((shift) => (
+                            {currentWeekShifts.map((shift) => (
                                 <TableRow key={shift.id}>
                                     <TableCell>
                                         <div className="flex items-center gap-2">
                                             <User className="h-4 w-4 text-muted-foreground" />
                                             {shift.chatter.full_name}
+                                        </div>
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex flex-wrap gap-1">
+                                            {shift.model_names.length === 0 && (
+                                                <Badge variant="outline" className="text-xs">
+                                                    Geen models
+                                                </Badge>
+                                            )}
+                                            {shift.model_names.map((name, index) => (
+                                                <Badge key={`${shift.id}-model-${index}`} variant="secondary" className="text-xs">
+                                                    {name}
+                                                </Badge>
+                                            ))}
                                         </div>
                                     </TableCell>
                                     <TableCell>
@@ -686,6 +1271,14 @@ export function ShiftManager() {
                                             )}
                                             <Button
                                                 size="sm"
+                                                variant="secondary"
+                                                onClick={() => openEditDialog(shift)}
+                                            >
+                                                <Pencil className="h-4 w-4 mr-1" />
+                                                Edit
+                                            </Button>
+                                            <Button
+                                                size="sm"
                                                 variant="outline"
                                                 onClick={() => confirmDeleteShift(shift.id)}
                                                 className="text-red-600 hover:text-red-700 hover:bg-red-50"
@@ -699,7 +1292,7 @@ export function ShiftManager() {
                         </TableBody>
                     </Table>
 
-                    {shifts.length === 0 && (
+                    {currentWeekShifts.length === 0 && (
                         <div className="text-center py-8 text-muted-foreground">
                             <Calendar className="h-12 w-12 mx-auto mb-4 opacity-50" />
                             <p>Geen komende shifts ingepland.</p>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -347,8 +347,13 @@ class ApiClient {
     return this.request(`/commissions/${id}`, { method: "DELETE" })
   }
 
-  getShifts() {
-    return this.request("/shifts")
+  getShifts(params?: { from?: string; to?: string; chatterId?: string }) {
+    const search = new URLSearchParams()
+    if (params?.from) search.set("from", params.from)
+    if (params?.to) search.set("to", params.to)
+    if (params?.chatterId) search.set("chatterId", params.chatterId)
+    const query = search.toString() ? `?${search.toString()}` : ""
+    return this.request(`/shifts${query}`)
   }
 
   getShift(id: string) {


### PR DESCRIPTION
## Summary
- add metadata caching and two-week shift fetching with prefetch support in the weekly calendar to keep navigation responsive while reducing payloads
- rework the shift manager to load two-week windows, keep daily schedules sorted, extend shift creation with an optional weekly repeat payload, and scope the management table to the currently selected week
- add an edit dialog and enhanced table controls so managers can adjust chatter, models, and times directly from the UI
- allow the API client to pass date ranges and chatter filters when requesting shifts

## Testing
- `npm run lint` *(fails: Next.js CLI is unavailable because dependencies cannot be installed in this environment; npm install is blocked with 403 responses from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ca80c7cb788327bfda4d51c9bf7104